### PR TITLE
Discard any "private" members of class in typescript while converting

### DIFF
--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -207,7 +207,10 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     memberBlock ^^ ObjectType
 
   lazy val memberBlock: Parser[List[MemberTree]] =
-    "{" ~> rep(typeMember <~ opt(";")) <~ "}"
+    "{" ~> rep(members <~ opt(";")) <~ "}" ^^ { case lst => lst.filterNot(null==) }
+
+  lazy val members: Parser[MemberTree] =
+    ("private" ~> maybeStaticPropName ^^ (_ => null)) | typeMember
 
   lazy val typeMember: Parser[MemberTree] =
     callMember | constructorMember | indexMember | namedMember


### PR DESCRIPTION
Hello,

While I attempt to "auto-convert" babylon.2.1.d.ts, I've error on private members.

So, I've modified to discard "private" members in typescript while converting to scala.js.

It's not the best solution but it works.

If you want, I think I can change the code to have private members conversion.

Thanks in advance.

Sorry for the auto-indent of eclipse :s
