### PR TITLE
Add partial support for associative array

### DIFF
--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -245,6 +245,10 @@ class Importer(val output: java.io.PrintWriter) {
         }
         TypeRef(baseTypeRef, targs map typeToScala)
 
+      case ObjectType(List(IndexMember(_, TypeRefTree(CoreType("string"), _), valueType))) =>
+        val valueTpe = typeToScala(valueType)
+        TypeRef(QualifiedName.Dictionary, List(valueTpe))
+
       case ObjectType(members) =>
         // ???
         TypeRef.Any

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -49,6 +49,7 @@ object QualifiedName {
   val java_lang = Root dot Name.java dot Name.lang
 
   val Array = scala_js dot Name("Array")
+  val Dictionary = scala_js dot Name("Dictionary")
   val FunctionBase = scala_js dot Name("Function")
   def Function(arity: Int) = scala_js dot Name("Function"+arity)
   val Union = scala_js dot Name("|")


### PR DESCRIPTION
- supports only string as key

Example:
```scala
      interface Test {
          values(obj: { [ key: string ] : string }): number;
      }
```