### PR TITLE
Support for tuples as js.Tuple

### DIFF
--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -280,6 +280,9 @@ class Importer(val output: java.io.PrintWriter) {
         TypeRef.Singleton(QualifiedName((expr.qualifier :+ expr.name).map(
             ident => Name(ident.name)): _*))
 
+      case TupleType(targs) =>
+          TypeRef(QualifiedName.Tuple(targs.length), targs map typeToScala)
+
       case RepeatedType(underlying) =>
         TypeRef(Name.REPEATED, List(typeToScala(underlying)))
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -131,6 +131,8 @@ object Trees {
 
   case class UnionType(left: TypeTree, right: TypeTree) extends TypeTree
 
+  case class TupleType(tparams: List[TypeTree]) extends TypeTree
+
   case class TypeQuery(expr: QualifiedIdent) extends TypeTree
 
   case class RepeatedType(underlying: TypeTree) extends TypeTree

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -190,6 +190,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     | objectType
     | functionType
     | typeQuery
+    | tupleType
     | "(" ~> typeDesc <~ ")"
   )
 
@@ -217,6 +218,11 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
   lazy val typeQuery: Parser[TypeTree] =
     "typeof" ~> rep1sep(ident, ".") ^^ { parts =>
       TypeQuery(QualifiedIdent(parts.init.map(Ident), Ident(parts.last)))
+    }
+
+  lazy val tupleType: Parser[TypeTree] =
+    "[" ~> rep1sep(typeDesc, ",") <~ "]" ^^ { parts =>
+      TupleType(parts)
     }
 
   lazy val objectType: Parser[TypeTree] =

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -52,6 +52,7 @@ object QualifiedName {
   val Dictionary = scala_js dot Name("Dictionary")
   val FunctionBase = scala_js dot Name("Function")
   def Function(arity: Int) = scala_js dot Name("Function"+arity)
+  def Tuple(arity: Int) = scala_js dot Name("Tuple"+arity)
   val Union = scala_js dot Name("|")
 }
 


### PR DESCRIPTION
Converts to js.Array[T] If all parameters are same like [number,number]
otherwise jsArray[Any]
until scala.js tuple is implemented and released
