### PR TITLE
initial Typescript2 support

### DIFF
--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -296,13 +296,15 @@ class Importer(val output: java.io.PrintWriter) {
       anyAsDynamic: Boolean = false): TypeRef = {
 
     tpe.name match {
-      case "any"     => if (anyAsDynamic) TypeRef.Dynamic else TypeRef.Any
-      case "dynamic" => TypeRef.Dynamic
-      case "void"    => TypeRef.Unit
-      case "number"  => TypeRef.Double
-      case "bool"    => TypeRef.Boolean
-      case "boolean" => TypeRef.Boolean
-      case "string"  => TypeRef.String
+      case "any"       => if (anyAsDynamic) TypeRef.Dynamic else TypeRef.Any
+      case "dynamic"   => TypeRef.Dynamic
+      case "void"      => TypeRef.Unit
+      case "number"    => TypeRef.Double
+      case "bool"      => TypeRef.Boolean
+      case "boolean"   => TypeRef.Boolean
+      case "string"    => TypeRef.String
+      case "null"      => TypeRef.Null
+      case "undefined" => TypeRef.Unit
     }
   }
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -23,7 +23,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
 
   lexical.reserved ++= List(
       // Value keywords
-      "true", "false", "null", "undefined",
+      "true", "false",
 
       // Current JavaScript keywords
       "break", "case", "catch", "continue", "debugger", "default", "delete",
@@ -272,7 +272,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     stringLit ^^ StringLiteral
 
   private val isCoreTypeName =
-    Set("any", "void", "number", "bool", "boolean", "string")
+    Set("any", "void", "number", "bool", "boolean", "string", "null", "undefined")
 
   def typeNameToTypeRef(name: String): BaseTypeRef =
     if (isCoreTypeName(name)) CoreType(name)

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -56,12 +56,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     rep(ambientDeclaration)
 
   lazy val ambientDeclaration: Parser[DeclTree] =
-    opt("declare") ~> ambientDeclaration1
-
-  lazy val ambientDeclaration1 = (
-      ambientModuleDecl | ambientVarDecl | ambientFunctionDecl
-    | ambientEnumDecl | ambientClassDecl | ambientInterfaceDecl
-  )
+    opt("declare") ~> opt("export") ~> moduleElementDecl1
 
   lazy val ambientModuleDecl: Parser[DeclTree] =
     ("module" | "namespace") ~> rep1sep(propertyName, ".") ~ moduleBody ^^ {

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -283,6 +283,7 @@ object TypeRef {
   val Object = TypeRef(scala_js dot Name("Object"))
   val Function = TypeRef(scala_js dot Name("Function"))
   val Unit = TypeRef(scala dot Name("Unit"))
+  val Null = TypeRef(scala dot Name("Null"))
 
   object Union {
     def apply(left: TypeRef, right: TypeRef): TypeRef =


### PR DESCRIPTION
- accept d.ts without module declaration block (omit export keyword)
- accept `null` and `undefined` as types