### PR TITLE
Add support for modifiers and const declarations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,10 @@ version := "0.1-SNAPSHOT"
 
 mainClass := Some("org.scalajs.tools.tsimporter.Main")
 
-libraryDependencies +=
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2"
+libraryDependencies ++= Seq(
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2",
+  "org.scalatest" %% "scalatest" % "3.0.3" % Test
+)
 
 organization := "org.scalajs.tools"
 
@@ -17,3 +19,5 @@ scalacOptions ++= Seq(
     "-feature",
     "-encoding", "utf8"
 )
+
+fork in Test := true

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -26,6 +26,20 @@ object Trees {
   sealed trait TypeTree extends Tree
   sealed trait MemberTree extends Tree
 
+  // Modifiers
+
+  abstract sealed class Modifier
+
+  object Modifier {
+    case object Public extends Modifier
+    case object Protected extends Modifier
+    case object Static extends Modifier
+    case object ReadOnly extends Modifier
+    case object Const extends Modifier
+  }
+
+  type Modifiers = Set[Modifier]
+
   // Identifiers and properties
 
   sealed trait PropertyName extends TermTree {
@@ -65,6 +79,8 @@ object Trees {
   case class ModuleDecl(name: PropertyName, members: List[DeclTree]) extends DeclTree
 
   case class VarDecl(name: Ident, tpe: Option[TypeTree]) extends DeclTree
+
+  case class ConstDecl(name: Ident, tpe: Option[TypeTree]) extends DeclTree
 
   case class FunctionDecl(name: Ident, signature: FunSignature) extends DeclTree
 
@@ -146,8 +162,8 @@ object Trees {
   case class IndexMember(indexName: Ident, indexType: TypeTree, valueType: TypeTree) extends MemberTree
 
   case class PropertyMember(name: PropertyName, optional: Boolean,
-      tpe: TypeTree, static: Boolean) extends MemberTree
+      tpe: TypeTree, modifiers: Modifiers) extends MemberTree
 
   case class FunctionMember(name: PropertyName, optional: Boolean,
-      signature: FunSignature, static: Boolean) extends MemberTree
+      signature: FunSignature, modifiers: Modifiers) extends MemberTree
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -10,6 +10,7 @@ import scala.language.implicitConversions
 import scala.collection.mutable._
 
 import org.scalajs.tools.tsimporter.Utils
+import org.scalajs.tools.tsimporter.Trees.{ Modifier, Modifiers }
 
 case class Name(name: String) {
   override def toString() = Utils.scalaEscape(name)
@@ -130,8 +131,8 @@ class ContainerSymbol(nme: Name) extends Symbol(nme) {
     result
   }
 
-  def newField(name: Name): FieldSymbol = {
-    val result = new FieldSymbol(name)
+  def newField(name: Name, modifiers: Modifiers): FieldSymbol = {
+    val result = new FieldSymbol(name, modifiers)
     members += result
     result
   }
@@ -195,10 +196,10 @@ class TypeAliasSymbol(nme: Name) extends Symbol(nme) {
       (if (tparams.isEmpty) "" else tparams.mkString("<", ", ", ">")))
 }
 
-class FieldSymbol(nme: Name) extends Symbol(nme) with JSNameable {
+class FieldSymbol(nme: Name, val modifiers: Modifiers) extends Symbol(nme) with JSNameable {
   var tpe: TypeRef = TypeRef.Any
 
-  override def toString() = s"${jsNameStr}var $name: $tpe"
+  override def toString() = s"${jsNameStr}${if (modifiers(Modifier.ReadOnly)) "val" else "var"} $name: $tpe"
 }
 
 class MethodSymbol(nme: Name) extends Symbol(nme) with JSNameable {

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
@@ -6,6 +6,7 @@
 package org.scalajs.tools.tsimporter.sc
 
 import java.io.PrintWriter
+import org.scalajs.tools.tsimporter.Trees.Modifier
 
 class Printer(private val output: PrintWriter, outputPackage: String) {
   import Printer._
@@ -123,7 +124,14 @@ class Printer(private val output: PrintWriter, outputPackage: String) {
         sym.jsName foreach { jsName =>
           pln"""  @JSName("$jsName")"""
         }
-        pln"  var $name: ${sym.tpe} = js.native"
+        val access =
+          if (sym.modifiers(Modifier.Protected)) "protected "
+          else ""
+        val decl =
+          if (sym.modifiers(Modifier.Const)) "val"
+          else if (sym.modifiers(Modifier.ReadOnly)) "def"
+          else "var"
+        pln"  $access$decl $name: ${sym.tpe} = js.native"
 
       case sym: MethodSymbol =>
         val params = sym.params

--- a/src/test/resources/samples/modifiers.ts
+++ b/src/test/resources/samples/modifiers.ts
@@ -1,0 +1,33 @@
+declare module monaco {
+
+  const id: string;
+
+  export class Emitter<T> {
+      constructor();
+      public readonly event: IEvent<T>;
+      fire(event?: T): void;
+      dispose(): void;
+  }
+
+  export var EditorType: {
+      ICodeEditor: string;
+      IDiffEditor: string;
+  };
+
+  export const CursorMoveByUnit: {
+      Line: string;
+      WrappedLine: string;
+      Character: string;
+      HalfLine: string;
+  };
+
+  export class Uri {
+      static isUri(thing: any): boolean;
+      public static parse(value: string): Uri;
+      protected constructor();
+      readonly scheme: string;
+      readonly authority: string;
+      readonly path: string;
+  }
+
+}

--- a/src/test/resources/samples/modifiers.ts.scala
+++ b/src/test/resources/samples/modifiers.ts.scala
@@ -1,0 +1,49 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package importedjs {
+
+package monaco {
+
+@js.native
+@JSName("monaco.Emitter")
+class Emitter[T] extends js.Object {
+  def event: IEvent[T] = js.native
+  def fire(event: T = ???): Unit = js.native
+  def dispose(): Unit = js.native
+}
+
+@js.native
+@JSName("monaco.EditorType")
+object EditorType extends js.Object {
+  var ICodeEditor: String = js.native
+  var IDiffEditor: String = js.native
+}
+
+@js.native
+@JSName("monaco.Uri")
+class Uri extends js.Object {
+  def scheme: String = js.native
+  def authority: String = js.native
+  def path: String = js.native
+}
+
+@js.native
+@JSName("monaco.Uri")
+object Uri extends js.Object {
+  def isUri(thing: js.Any): Boolean = js.native
+  def parse(value: String): Uri = js.native
+}
+
+@JSName("monaco")
+@js.native
+object Monaco extends js.Object {
+  val id: String = js.native
+  val CursorMoveByUnit: js.Any = js.native
+}
+
+}
+
+}

--- a/src/test/scala/org/scalajs/tools/tsimporter/ImporterSpec.scala
+++ b/src/test/scala/org/scalajs/tools/tsimporter/ImporterSpec.scala
@@ -1,0 +1,30 @@
+package org.scalajs.tools.tsimporter
+
+import java.io.{ File, FilenameFilter }
+import org.scalatest.FunSpec
+import scala.io.Source
+
+class ImporterSpec extends FunSpec {
+  describe("Main.main") {
+    val inputDirectory = new File("src/test/resources/samples")
+
+    val outputDir = new File("target/tsimporter-test")
+    Option(outputDir.listFiles()).foreach(_.foreach(_.delete()))
+    outputDir.mkdirs()
+
+    def contentOf(file: File) =
+      Source.fromFile(file).getLines.mkString("\n")
+
+    for (input <- inputDirectory.listFiles() if input.getName.endsWith(".ts")) {
+      it(s"should import ${input.getName}") {
+        val expected = new File(inputDirectory, input.getName + ".scala")
+        val output = new File(outputDir, input.getName + ".scala")
+
+        Main.main(Array(input.getAbsolutePath, output.getAbsolutePath))
+
+        assert(output.exists())
+        assert(contentOf(output) == contentOf(expected))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Parse "public", "protected" as well as "readonly" modifiers and
translate the two latter into Scala's protected modifier and field
declaration with "val" instead of "var". Similarly parse "const"
declarations and translate them to "val" fields.

---

Some changes made to facilitate generating a facade for [monaco.d.ts](https://github.com/Microsoft/monaco-editor/blob/06c48a7281d5728ad9f46185330be6e2ada29334/monaco.d.ts) as part of scalameta/metadoc#17