### PR TITLE
Add support for never type

### DIFF
--- a/samples/never.ts
+++ b/samples/never.ts
@@ -1,6 +1,8 @@
 declare module nevertype {
 
   export class ValueTermQueryBase {
+      never: never;
+
       value(queryVal: string | number): string;
   }
 

--- a/samples/never.ts
+++ b/samples/never.ts
@@ -1,19 +1,11 @@
 declare module nevertype {
 
-  export class ValueTermQueryBase {
+  export class RangeQuery {
       never: never;
 
       value(queryVal: string | number): string;
 
       method(foo: never): Array<never>;
-  }
-
-  export class RangeQuery extends ValueTermQueryBase {
-      /**
-       * @override
-       * @throws {Error} This method cannot be called on RangeQuery
-       */
-      value(queryVal: string | number): never;
   }
 
 }

--- a/samples/never.ts
+++ b/samples/never.ts
@@ -4,6 +4,8 @@ declare module nevertype {
       never: never;
 
       value(queryVal: string | number): string;
+
+      method(foo: never): Array<never>;
   }
 
   export class RangeQuery extends ValueTermQueryBase {

--- a/samples/never.ts
+++ b/samples/never.ts
@@ -12,11 +12,4 @@ declare module nevertype {
       value(queryVal: string | number): never;
   }
 
-  export class RangeQuery2 extends ValueTermQueryBase {
-      /**
-       * @override
-       * @throws {Error} This method cannot be called on RangeQuery
-       */
-      value(): never;
-  }
 }

--- a/samples/never.ts
+++ b/samples/never.ts
@@ -1,0 +1,22 @@
+declare module nevertype {
+
+  export class ValueTermQueryBase {
+      value(queryVal: string | number): string;
+  }
+
+  export class RangeQuery extends ValueTermQueryBase {
+      /**
+       * @override
+       * @throws {Error} This method cannot be called on RangeQuery
+       */
+      value(queryVal: string | number): never;
+  }
+
+  export class RangeQuery2 extends ValueTermQueryBase {
+      /**
+       * @override
+       * @throws {Error} This method cannot be called on RangeQuery
+       */
+      value(): never;
+  }
+}

--- a/samples/never.ts.scala
+++ b/samples/never.ts.scala
@@ -19,12 +19,6 @@ class RangeQuery extends ValueTermQueryBase {
   def value(queryVal: String | Double): Nothing = js.native
 }
 
-@js.native
-@JSGlobal("nevertype.RangeQuery2")
-class RangeQuery2 extends ValueTermQueryBase {
-  def value(): Nothing = js.native
-}
-
 }
 
 }

--- a/samples/never.ts.scala
+++ b/samples/never.ts.scala
@@ -8,17 +8,11 @@ package importedjs {
 package nevertype {
 
 @js.native
-@JSGlobal("nevertype.ValueTermQueryBase")
-class ValueTermQueryBase extends js.Object {
+@JSGlobal("nevertype.RangeQuery")
+class RangeQuery extends js.Object {
   var never: Nothing = js.native
   def value(queryVal: String | Double): String = js.native
   def method(foo: Nothing): js.Array[Nothing] = js.native
-}
-
-@js.native
-@JSGlobal("nevertype.RangeQuery")
-class RangeQuery extends ValueTermQueryBase {
-  def value(queryVal: String | Double): Nothing = js.native
 }
 
 }

--- a/samples/never.ts.scala
+++ b/samples/never.ts.scala
@@ -12,6 +12,7 @@ package nevertype {
 class ValueTermQueryBase extends js.Object {
   var never: Nothing = js.native
   def value(queryVal: String | Double): String = js.native
+  def method(foo: Nothing): js.Array[Nothing] = js.native
 }
 
 @js.native

--- a/samples/never.ts.scala
+++ b/samples/never.ts.scala
@@ -10,6 +10,7 @@ package nevertype {
 @js.native
 @JSGlobal("nevertype.ValueTermQueryBase")
 class ValueTermQueryBase extends js.Object {
+  var never: Nothing = js.native
   def value(queryVal: String | Double): String = js.native
 }
 

--- a/samples/never.ts.scala
+++ b/samples/never.ts.scala
@@ -1,0 +1,30 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package importedjs {
+
+package nevertype {
+
+@js.native
+@JSGlobal("nevertype.ValueTermQueryBase")
+class ValueTermQueryBase extends js.Object {
+  def value(queryVal: String | Double): String = js.native
+}
+
+@js.native
+@JSGlobal("nevertype.RangeQuery")
+class RangeQuery extends ValueTermQueryBase {
+  def value(queryVal: String | Double): Nothing = js.native
+}
+
+@js.native
+@JSGlobal("nevertype.RangeQuery2")
+class RangeQuery2 extends ValueTermQueryBase {
+  def value(): Nothing = js.native
+}
+
+}
+
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -322,6 +322,7 @@ class Importer(val output: java.io.PrintWriter) {
       case "string"    => TypeRef.String
       case "null"      => TypeRef.Null
       case "undefined" => TypeRef.Unit
+      case "never"     => TypeRef.Nothing
     }
   }
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -162,6 +162,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
 
   lazy val resultType: Parser[TypeTree] = (
       ("void" ^^^ TypeRef(CoreType("void")))
+    | ("never" ^^^ TypeRef(CoreType("never")))
     | typeDesc
   )
 
@@ -282,7 +283,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     stringLit ^^ StringLiteral
 
   private val isCoreTypeName =
-    Set("any", "void", "number", "bool", "boolean", "string", "null", "undefined")
+    Set("any", "void", "number", "bool", "boolean", "string", "null", "undefined", "never")
 
   def typeNameToTypeRef(name: String): BaseTypeRef =
     if (isCoreTypeName(name)) CoreType(name)

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -162,7 +162,6 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
 
   lazy val resultType: Parser[TypeTree] = (
       ("void" ^^^ TypeRef(CoreType("void")))
-    | ("never" ^^^ TypeRef(CoreType("never")))
     | typeDesc
   )
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -298,6 +298,7 @@ object TypeRef {
   val Function = TypeRef(scala_js dot Name("Function"))
   val Unit = TypeRef(scala dot Name("Unit"))
   val Null = TypeRef(scala dot Name("Null"))
+  val Nothing = TypeRef(scala dot Name("Nothing"))
 
   object Union {
     def apply(types: List[TypeRef]): TypeRef =


### PR DESCRIPTION
Converts the `never` type to `Nothing` type.

[The `never` type](https://www.typescriptlang.org/docs/handbook/basic-types.html#never) is a bottom type and can represent the types of value that never occurs, just like [the `Nothing` type](http://www.scala-lang.org/api/2.12.3/scala/Nothing.html) do so in Scala.

Some example of using `never` in type definitions. 
* To prevent using a method in sub class https://github.com/sudo-suhas/elastic-builder/blob/4c454fd3c345ae7de09cd5ad27dcac9479a71cf6/src/index.d.ts#L1394
* To indicate a function that shutdown the system (hence the return value can't be used) https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1aefe0126e5e4ea8fbf0e98661e12439c42dd4e3/types/node/index.d.ts#L459