### PR TITLE
Add support for "export let" and "export const" for modules

### DIFF
--- a/samples/modifiers.ts
+++ b/samples/modifiers.ts
@@ -2,6 +2,8 @@ declare module modifiers {
 
   const id: string;
 
+  let name: string;
+
   interface IEvent<T> {}
 
   export class Emitter<T> {

--- a/samples/modifiers.ts
+++ b/samples/modifiers.ts
@@ -16,6 +16,11 @@ declare module modifiers {
       IDiffEditor: string;
   };
 
+  export let EditorType2: {
+      ICodeEditor: string;
+      IDiffEditor: string;
+  };
+
   export const CursorMoveByUnit: {
       Line: string;
       WrappedLine: string;

--- a/samples/modifiers.ts.scala
+++ b/samples/modifiers.ts.scala
@@ -61,6 +61,7 @@ object Uri extends js.Object {
 @JSGlobal("modifiers")
 object Modifiers extends js.Object {
   val id: String = js.native
+  def name: String = js.native
 }
 
 }

--- a/samples/modifiers.ts.scala
+++ b/samples/modifiers.ts.scala
@@ -29,17 +29,17 @@ object EditorType extends js.Object {
 @js.native
 @JSGlobal("modifiers.EditorType2")
 object EditorType2 extends js.Object {
-  val ICodeEditor: String = js.native
-  val IDiffEditor: String = js.native
+  var ICodeEditor: String = js.native
+  var IDiffEditor: String = js.native
 }
 
 @js.native
 @JSGlobal("modifiers.CursorMoveByUnit")
 object CursorMoveByUnit extends js.Object {
-  val Line: String = js.native
-  val WrappedLine: String = js.native
-  val Character: String = js.native
-  val HalfLine: String = js.native
+  var Line: String = js.native
+  var WrappedLine: String = js.native
+  var Character: String = js.native
+  var HalfLine: String = js.native
 }
 
 @js.native

--- a/samples/modifiers.ts.scala
+++ b/samples/modifiers.ts.scala
@@ -27,6 +27,22 @@ object EditorType extends js.Object {
 }
 
 @js.native
+@JSGlobal("modifiers.EditorType2")
+object EditorType2 extends js.Object {
+  val ICodeEditor: String = js.native
+  val IDiffEditor: String = js.native
+}
+
+@js.native
+@JSGlobal("modifiers.CursorMoveByUnit")
+object CursorMoveByUnit extends js.Object {
+  val Line: String = js.native
+  val WrappedLine: String = js.native
+  val Character: String = js.native
+  val HalfLine: String = js.native
+}
+
+@js.native
 @JSGlobal("modifiers.Uri")
 class Uri extends js.Object {
   def scheme: String = js.native
@@ -45,7 +61,6 @@ object Uri extends js.Object {
 @JSGlobal("modifiers")
 object Modifiers extends js.Object {
   val id: String = js.native
-  val CursorMoveByUnit: js.Any = js.native
 }
 
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -39,6 +39,14 @@ class Importer(val output: java.io.PrintWriter) {
         val sym = owner.getModuleOrCreate(name)
         processMembersDecls(owner, sym, members)
 
+      case ConstDecl(IdentName(name), Some(tpe @ ObjectType(members))) =>
+        val sym = owner.getModuleOrCreate(name)
+        processMembersDecls(owner, sym, members)
+
+      case LetDecl(IdentName(name), Some(tpe @ ObjectType(members))) =>
+        val sym = owner.getModuleOrCreate(name)
+        processMembersDecls(owner, sym, members)
+
       case TypeDecl(TypeNameName(name), tpe @ ObjectType(members)) =>
         val sym = owner.getClassOrCreate(name)
         processMembersDecls(owner, sym, members)

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -109,6 +109,10 @@ class Importer(val output: java.io.PrintWriter) {
         val sym = owner.newField(name, Set(Modifier.Const))
         sym.tpe = typeToScala(tpe)
 
+      case LetDecl(IdentName(name), TypeOrAny(tpe)) =>
+        val sym = owner.newField(name, Set(Modifier.ReadOnly))
+        sym.tpe = typeToScala(tpe)
+
       case FunctionDecl(IdentName(name), signature) =>
         processDefDecl(owner, name, signature)
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -82,6 +82,8 @@ object Trees {
 
   case class ConstDecl(name: Ident, tpe: Option[TypeTree]) extends DeclTree
 
+  case class LetDecl(name: Ident, tpe: Option[TypeTree]) extends DeclTree
+
   case class FunctionDecl(name: Ident, signature: FunSignature) extends DeclTree
 
   // Function signature

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -80,11 +80,14 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
   lazy val moduleElementDecl1: Parser[DeclTree] = (
       ambientModuleDecl | ambientVarDecl | ambientFunctionDecl
     | ambientEnumDecl | ambientClassDecl | ambientInterfaceDecl
-    | ambientConstDecl | typeAliasDecl
+    | ambientConstDecl | ambientLetDecl | typeAliasDecl
   )
 
   lazy val ambientVarDecl: Parser[DeclTree] =
     "var" ~> identifier ~ optTypeAnnotation <~ opt(";") ^^ VarDecl
+
+  lazy val ambientLetDecl: Parser[DeclTree] =
+    "let" ~> identifier ~ optTypeAnnotation <~ opt(";") ^^ LetDecl
 
   lazy val ambientConstDecl: Parser[DeclTree] =
     "const" ~> identifier ~ optTypeAnnotation <~ opt(";") ^^ ConstDecl


### PR DESCRIPTION
* Add `export let myValue: string` support
  * I think it is better to make the `let`-exported values read-only (converted to`def myVar: ... `), since the value may be updated within the module.
* Add `export let myModule: { ... }` support
* Add `export const myModule: { ... }` support, which I suppose it was missed in #38 for some reason.

