### PR TITLE
Add support for the polymorphic this type

### DIFF
--- a/samples/thistype.ts
+++ b/samples/thistype.ts
@@ -1,0 +1,7 @@
+declare module thistype {
+
+  export class A {
+    merge(other: this): this;
+  }
+
+}

--- a/samples/thistype.ts.scala
+++ b/samples/thistype.ts.scala
@@ -1,0 +1,18 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package importedjs {
+
+package thistype {
+
+@js.native
+@JSGlobal("thistype.A")
+class A extends js.Object {
+  def merge(other: this.type): this.type = js.native
+}
+
+}
+
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -315,6 +315,9 @@ class Importer(val output: java.io.PrintWriter) {
       case RepeatedType(underlying) =>
         TypeRef(Name.REPEATED, List(typeToScala(underlying)))
 
+      case PolymorphicThisType =>
+        TypeRef.ThisType
+
       case _ =>
         // ???
         TypeRef.Any

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -316,7 +316,7 @@ class Importer(val output: java.io.PrintWriter) {
         TypeRef(Name.REPEATED, List(typeToScala(underlying)))
 
       case PolymorphicThisType =>
-        TypeRef.ThisType
+        TypeRef.This
 
       case _ =>
         // ???

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -155,6 +155,8 @@ object Trees {
 
   case class RepeatedType(underlying: TypeTree) extends TypeTree
 
+  object PolymorphicThisType extends TypeTree
+
   // Type members
 
   case class CallMember(signature: FunSignature) extends MemberTree

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -194,6 +194,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     | stringType
     | typeQuery
     | tupleType
+    | thisType
     | "(" ~> typeDesc <~ ")"
   )
 
@@ -220,6 +221,9 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
 
   lazy val stringType: Parser[TypeTree] =
     stringLiteral ^^ ConstantType
+
+  lazy val thisType: Parser[TypeTree] =
+    "this" ^^^ PolymorphicThisType
 
   lazy val typeQuery: Parser[TypeTree] =
     "typeof" ~> rep1sep(ident, ".") ^^ { parts =>

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -299,7 +299,9 @@ object TypeRef {
   val Unit = TypeRef(scala dot Name("Unit"))
   val Null = TypeRef(scala dot Name("Null"))
   val Nothing = TypeRef(scala dot Name("Nothing"))
-  val ThisType = TypeRef(scala dot Name("this") dot Name("type"))
+  val ThisType = TypeRef(new Name("this.type") {
+    override def toString(): String = "this.type"
+  })
 
   object Union {
     def apply(types: List[TypeRef]): TypeRef =

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -27,6 +27,7 @@ object Name {
   val CONSTRUCTOR = Name("<init>")
   val REPEATED = Name("*")
   val SINGLETON = Name("<typeof>")
+  val THIS = Name("<this>")
 }
 
 case class QualifiedName(parts: Name*) {
@@ -299,9 +300,7 @@ object TypeRef {
   val Unit = TypeRef(scala dot Name("Unit"))
   val Null = TypeRef(scala dot Name("Null"))
   val Nothing = TypeRef(scala dot Name("Nothing"))
-  val ThisType = TypeRef(new Name("this.type") {
-    override def toString(): String = "this.type"
-  })
+  val This = Singleton(QualifiedName(Name.THIS))
 
   object Union {
     def apply(types: List[TypeRef]): TypeRef =

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -299,6 +299,7 @@ object TypeRef {
   val Unit = TypeRef(scala dot Name("Unit"))
   val Null = TypeRef(scala dot Name("Null"))
   val Nothing = TypeRef(scala dot Name("Nothing"))
+  val ThisType = TypeRef(scala dot Name("this") dot Name("type"))
 
   object Union {
     def apply(types: List[TypeRef]): TypeRef =

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
@@ -197,6 +197,9 @@ class Printer(private val output: PrintWriter, outputPackage: String) {
         implicit val withPipe = ListElemSeparator.Pipe
         p"$types"
 
+      case TypeRef.This =>
+        p"this.type"
+
       case TypeRef.Singleton(termRef) =>
         p"$termRef.type"
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
@@ -190,6 +190,9 @@ class Printer(private val output: PrintWriter, outputPackage: String) {
 
   def printTypeRef(tpe: TypeRef) {
     tpe match {
+      case TypeRef.ThisType =>
+        p"this.type"
+
       case TypeRef(typeName, Nil) =>
         p"$typeName"
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
@@ -190,9 +190,6 @@ class Printer(private val output: PrintWriter, outputPackage: String) {
 
   def printTypeRef(tpe: TypeRef) {
     tpe match {
-      case TypeRef.ThisType =>
-        p"this.type"
-
       case TypeRef(typeName, Nil) =>
         p"$typeName"
 


### PR DESCRIPTION
Converts TypeScript's the polymorphic `this` type to Scala's `this.type`.
The [polymorphic this type](https://www.typescriptlang.org/docs/handbook/advanced-types.html#polymorphic-this-types) is useful to express hierarchical fluent interfaces easily.

Use cases
* [jQuery's index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f02ac07f965ae89a935b1016130f03ce7387bd7b/types/jquery/index.d.ts#L2981)
* [pixi.js.d.ts](https://github.com/pixijs/pixi-typescript/blob/d76f75ccef19d46b5a793d73803661c57480a3a7/pixi.js.d.ts#L414)
* [archiver's index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f02ac07f965ae89a935b1016130f03ce7387bd7b/types/archiver/index.d.ts#L26)