### PR TITLE
Allow parsing of ambient declarations starting with "export declare"

### DIFF
--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -56,8 +56,10 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
   lazy val ambientDeclarations: Parser[List[DeclTree]] =
     rep(ambientDeclaration)
 
-  lazy val ambientDeclaration: Parser[DeclTree] =
-    opt("declare") ~> opt("export") ~> moduleElementDecl1
+  lazy val ambientDeclaration: Parser[DeclTree] = (
+      opt("declare") ~> opt("export") ~> moduleElementDecl1
+    | opt("export") ~> opt("declare") ~> moduleElementDecl1
+  )
 
   lazy val ambientModuleDecl: Parser[DeclTree] =
     ("module" | "namespace") ~> rep1sep(propertyName, ".") ~ moduleBody ^^ {


### PR DESCRIPTION
Occurs in TS compiler generated d.ts files i.e. seen in https://github.com/PAIR-code/deeplearnjs