### PR TITLE
Generate @JSGlobalScope annotation for global vars and functions

### DIFF
--- a/samples/jsglobal.ts
+++ b/samples/jsglobal.ts
@@ -15,3 +15,7 @@ declare module nested {
         static isCirce(thing: any): boolean;
     }
 }
+
+declare const globalConst: String;
+declare let globalVar: String;
+declare function globalFunc(): String;

--- a/samples/jsglobal.ts.scala
+++ b/samples/jsglobal.ts.scala
@@ -43,4 +43,12 @@ object Nested extends js.Object {
 
 }
 
+@js.native
+@JSGlobalScope
+object Importedjs extends js.Object {
+  val globalConst: String = js.native
+  def globalVar: String = js.native
+  def globalFunc(): String = js.native
+}
+
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
@@ -60,8 +60,8 @@ class Printer(private val output: PrintWriter, outputPackage: String) {
             pln"";
             if (currentJSNamespace.isEmpty) {
               pln"@js.native"
-              pln"@JSGlobal"
-              pln"object $packageObjectName extends js.GlobalScope {"
+              pln"@JSGlobalScope"
+              pln"object $packageObjectName extends js.Object {"
             } else {
               val jsName = currentJSNamespace.init
               pln"@js.native"


### PR DESCRIPTION
Instead of extending from deprecated js.GlobalScope.

As discussed in https://github.com/sjrd/scala-js-ts-importer/pull/43#pullrequestreview-68755760