### PR TITLE
Put samples into individual packages to avoid naming conflicts

### DIFF
--- a/samples/jsglobal.ts.scala
+++ b/samples/jsglobal.ts.scala
@@ -3,7 +3,7 @@ import scala.scalajs.js
 import js.annotation._
 import js.|
 
-package importedjs {
+package jsglobal {
 
 @js.native
 @JSGlobal
@@ -45,7 +45,7 @@ object Nested extends js.Object {
 
 @js.native
 @JSGlobalScope
-object Importedjs extends js.Object {
+object Jsglobal extends js.Object {
   val globalConst: String = js.native
   def globalVar: String = js.native
   def globalFunc(): String = js.native

--- a/samples/modifiers.ts.scala
+++ b/samples/modifiers.ts.scala
@@ -3,7 +3,7 @@ import scala.scalajs.js
 import js.annotation._
 import js.|
 
-package importedjs {
+package modifiers {
 
 package modifiers {
 

--- a/samples/never.ts.scala
+++ b/samples/never.ts.scala
@@ -3,7 +3,7 @@ import scala.scalajs.js
 import js.annotation._
 import js.|
 
-package importedjs {
+package never {
 
 package nevertype {
 

--- a/samples/overrides.ts.scala
+++ b/samples/overrides.ts.scala
@@ -3,7 +3,7 @@ import scala.scalajs.js
 import js.annotation._
 import js.|
 
-package importedjs {
+package overrides {
 
 package overrides {
 

--- a/samples/stringlit.ts.scala
+++ b/samples/stringlit.ts.scala
@@ -3,7 +3,7 @@ import scala.scalajs.js
 import js.annotation._
 import js.|
 
-package importedjs {
+package stringlit {
 
 package stringlit {
 

--- a/samples/then.ts.scala
+++ b/samples/then.ts.scala
@@ -3,7 +3,7 @@ import scala.scalajs.js
 import js.annotation._
 import js.|
 
-package importedjs {
+package `then` {
 
 package `then` {
 

--- a/samples/thistype.ts.scala
+++ b/samples/thistype.ts.scala
@@ -3,7 +3,7 @@ import scala.scalajs.js
 import js.annotation._
 import js.|
 
-package importedjs {
+package thistype {
 
 package thistype {
 

--- a/src/test/scala/org/scalajs/tools/tsimporter/ImporterSpec.scala
+++ b/src/test/scala/org/scalajs/tools/tsimporter/ImporterSpec.scala
@@ -20,7 +20,7 @@ class ImporterSpec extends FunSpec {
         val expected = new File(inputDirectory, input.getName + ".scala")
         val output = new File(outputDir, input.getName + ".scala")
 
-        Main.main(Array(input.getAbsolutePath, output.getAbsolutePath))
+        Main.main(Array(input.getAbsolutePath, output.getAbsolutePath, input.getName.takeWhile(_ != '.')))
 
         assert(output.exists())
         assert(contentOf(output) == contentOf(expected))


### PR DESCRIPTION
Again related to #43 I have naming conflicts in the samples caused by multiple globals each creating an `Importedjs` object.

So my suggestion would be to just move everything into its own package.