### PR TITLE
Add support for the intersection type `A & B`

### DIFF
--- a/samples/intersectiontype.ts
+++ b/samples/intersectiontype.ts
@@ -1,0 +1,21 @@
+declare namespace intersectiontype {
+
+    type ArchiverOptions = CoreOptions & ExtraOptions & MoreExtraOptions;
+    type UnionOfIntersection = CoreOptions | CoreOptions & ExtraOptions | CoreOptions & MoreExtraOptions;
+    type Duplicates = CoreOptions & CoreOptions & ExtraOptions & MoreExtraOptions;
+
+    interface CoreOptions {
+        statConcurrency: number;
+    }
+
+    interface ExtraOptions {
+        allowHalfOpen: boolean;
+    }
+
+    interface MoreExtraOptions {
+        store: boolean;
+    }
+
+    export function test(v : CoreOptions & ExtraOptions): CoreOptions & MoreExtraOptions;
+
+}

--- a/samples/intersectiontype.ts.scala
+++ b/samples/intersectiontype.ts.scala
@@ -1,0 +1,36 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package intersectiontype {
+
+package intersectiontype {
+
+@js.native
+trait CoreOptions extends js.Object {
+  var statConcurrency: Double = js.native
+}
+
+@js.native
+trait ExtraOptions extends js.Object {
+  var allowHalfOpen: Boolean = js.native
+}
+
+@js.native
+trait MoreExtraOptions extends js.Object {
+  var store: Boolean = js.native
+}
+
+@js.native
+@JSGlobal("intersectiontype")
+object Intersectiontype extends js.Object {
+  type ArchiverOptions = CoreOptions with ExtraOptions with MoreExtraOptions
+  type UnionOfIntersection = CoreOptions | CoreOptions with ExtraOptions | CoreOptions with MoreExtraOptions
+  type Duplicates = CoreOptions with ExtraOptions with MoreExtraOptions
+  def test(v: CoreOptions with ExtraOptions): CoreOptions with MoreExtraOptions = js.native
+}
+
+}
+
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -295,6 +295,17 @@ class Importer(val output: java.io.PrintWriter) {
           TypeRef(QualifiedName.Function(params.size), targs)
         }
 
+      case IntersectionType(left, right) =>
+        def visit(tpe: TypeTree, visited: List[TypeRef]): List[TypeRef] = {
+          tpe match {
+            case IntersectionType(left, right) =>
+              visit(left, visit(right, visited))
+            case _ =>
+              typeToScala(tpe) :: visited
+          }
+        }
+        TypeRef.Intersection(visit(tpe, Nil).distinct)
+
       case UnionType(left, right) =>
         def visit(tpe: TypeTree, visited: List[TypeRef]): List[TypeRef] = {
           tpe match {

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -151,6 +151,8 @@ object Trees {
 
   case class UnionType(left: TypeTree, right: TypeTree) extends TypeTree
 
+  case class IntersectionType(left: TypeTree, right: TypeTree) extends TypeTree
+
   case class TupleType(tparams: List[TypeTree]) extends TypeTree
 
   case class TypeQuery(expr: QualifiedIdent) extends TypeTree

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -47,7 +47,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
       "{", "}", "(", ")", "[", "]", "<", ">",
       ".", ";", ",", "?", ":", "=", "|", "*",
       // TypeScript-specific
-      "...", "=>"
+      "...", "=>", "&"
   )
 
   def parseDefinitions(input: Reader[Char]) =
@@ -190,8 +190,16 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     ":" ~> typeDesc
 
   lazy val typeDesc: Parser[TypeTree] =
-    rep1sep(singleTypeDesc, "|") ^^ {
+    unionTypeDesc
+
+  lazy val unionTypeDesc: Parser[TypeTree] =
+    rep1sep(intersectionTypeDesc, "|") ^^ {
       _.reduceLeft(UnionType)
+    }
+
+  lazy val intersectionTypeDesc: Parser[TypeTree] =
+    rep1sep(singleTypeDesc, "&") ^^ {
+      _.reduceLeft(IntersectionType)
     }
 
   lazy val singleTypeDesc: Parser[TypeTree] =

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -45,9 +45,9 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
 
   lexical.delimiters ++= List(
       "{", "}", "(", ")", "[", "]", "<", ">",
-      ".", ";", ",", "?", ":", "=", "|", "*",
+      ".", ";", ",", "?", ":", "=", "|", "&", "*",
       // TypeScript-specific
-      "...", "=>", "&"
+      "...", "=>"
   )
 
   def parseDefinitions(input: Reader[Char]) =

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -314,6 +314,18 @@ object TypeRef {
     }
   }
 
+  object Intersection {
+    def apply(types: List[TypeRef]): TypeRef =
+      TypeRef(QualifiedName.Root, types)
+
+    def unapply(typeRef: TypeRef): Option[List[TypeRef]] = typeRef match {
+      case TypeRef(QualifiedName.Root, types) =>
+        Some(types)
+
+      case _ => None
+    }
+  }
+
   object Singleton {
     def apply(underlying: QualifiedName): TypeRef =
       TypeRef(QualifiedName(Name.SINGLETON), List(TypeRef(underlying)))

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -28,6 +28,7 @@ object Name {
   val REPEATED = Name("*")
   val SINGLETON = Name("<typeof>")
   val THIS = Name("<this>")
+  val INTERSECTION = Name("<with>")
 }
 
 case class QualifiedName(parts: Name*) {
@@ -56,6 +57,7 @@ object QualifiedName {
   def Function(arity: Int) = scala_js dot Name("Function"+arity)
   def Tuple(arity: Int) = scala_js dot Name("Tuple"+arity)
   val Union = scala_js dot Name("|")
+  val Intersection = QualifiedName(Name.INTERSECTION)
 }
 
 class Symbol(val name: Name) {
@@ -316,10 +318,10 @@ object TypeRef {
 
   object Intersection {
     def apply(types: List[TypeRef]): TypeRef =
-      TypeRef(QualifiedName.Root, types)
+      TypeRef(QualifiedName.Intersection, types)
 
     def unapply(typeRef: TypeRef): Option[List[TypeRef]] = typeRef match {
-      case TypeRef(QualifiedName.Root, types) =>
+      case TypeRef(QualifiedName.Intersection, types) =>
         Some(types)
 
       case _ => None

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
@@ -198,7 +198,7 @@ class Printer(private val output: PrintWriter, outputPackage: String) {
         p"$types"
 
       case TypeRef.Intersection(types) =>
-        implicit val withPipe = ListElemSeparator.WithKeyword
+        implicit val withWith = ListElemSeparator.WithKeyword
         p"$types"
 
       case TypeRef.This =>

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
@@ -197,6 +197,10 @@ class Printer(private val output: PrintWriter, outputPackage: String) {
         implicit val withPipe = ListElemSeparator.Pipe
         p"$types"
 
+      case TypeRef.Intersection(types) =>
+        implicit val withPipe = ListElemSeparator.WithKeyword
+        p"$types"
+
       case TypeRef.This =>
         p"this.type"
 


### PR DESCRIPTION
Convert the intersection type `A & B & C` into `A with B with C`.

It can be used to express using mixins, as seen in [jQuery](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/25b68c5aa3cfc9454672ef909568bca341a57ee0/types/jquery/index.d.ts#L2668), [React](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3ad090bdf675a2ddd7c4fcb5ccee9d4a3bb23b1d/types/react/index.d.ts#L210) or [Archiver](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f02ac07f965ae89a935b1016130f03ce7387bd7b/types/archiver/index.d.ts#L43)
