### PR TITLE
Add number literal type

### DIFF
--- a/samples/numberlit.ts
+++ b/samples/numberlit.ts
@@ -1,0 +1,10 @@
+declare module numberlit {
+
+    export type HttpStatuscode = 200 | 404 | 503 ;
+
+    export interface Machine {
+        state?: 0 | 1;
+
+        setState(flag: 0 | 1 | boolean): 0 | 1;
+    }
+}

--- a/samples/numberlit.ts
+++ b/samples/numberlit.ts
@@ -2,6 +2,9 @@ declare module numberlit {
 
     export type HttpStatuscode = 200 | 404 | 503 ;
 
+    // 1 to Int, 1.0 (which is valid-int) to Double
+    export function floating(prob: 0.1 | 0.5 | 1.0): 0.0 | 1
+
     export interface Machine {
         state?: 0 | 1;
 

--- a/samples/numberlit.ts.scala
+++ b/samples/numberlit.ts.scala
@@ -1,0 +1,24 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package importedjs {
+
+package numberlit {
+
+@js.native
+trait Machine extends js.Object {
+  var state: Int = js.native
+  def setState(flag: Int | Boolean): Int = js.native
+}
+
+@js.native
+@JSGlobal("numberlit")
+object Numberlit extends js.Object {
+  type HttpStatuscode = Int
+}
+
+}
+
+}

--- a/samples/numberlit.ts.scala
+++ b/samples/numberlit.ts.scala
@@ -3,7 +3,7 @@ import scala.scalajs.js
 import js.annotation._
 import js.|
 
-package importedjs {
+package numberlit {
 
 package numberlit {
 
@@ -17,6 +17,7 @@ trait Machine extends js.Object {
 @JSGlobal("numberlit")
 object Numberlit extends js.Object {
   type HttpStatuscode = Int
+  def floating(prob: Double): Double | Int = js.native
 }
 
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -270,8 +270,8 @@ class Importer(val output: java.io.PrintWriter) {
       case ConstantType(StringLiteral(_)) =>
         TypeRef.String
 
-      case ConstantType(NumberLiteral(d, hasFloating)) =>
-        if (!hasFloating && d.isValidInt) {
+      case ConstantType(NumberLiteral(d, isValidInt)) =>
+        if (isValidInt) {
           TypeRef.Int
         } else {
           TypeRef.Double

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -270,12 +270,11 @@ class Importer(val output: java.io.PrintWriter) {
       case ConstantType(StringLiteral(_)) =>
         TypeRef.String
 
-      case ConstantType(NumberLiteral(d, isValidInt)) =>
-        if (isValidInt) {
-          TypeRef.Int
-        } else {
-          TypeRef.Double
-        }
+      case ConstantType(IntLiteral(i)) =>
+        TypeRef.Int
+
+      case ConstantType(DoubleLiteral(d)) =>
+        TypeRef.Double
 
       case ObjectType(List(IndexMember(_, TypeRefTree(CoreType("string"), _), valueType))) =>
         val valueTpe = typeToScala(valueType)

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -270,6 +270,13 @@ class Importer(val output: java.io.PrintWriter) {
       case ConstantType(StringLiteral(_)) =>
         TypeRef.String
 
+      case ConstantType(NumberLiteral(d)) =>
+        if (d.isValidInt) {
+          TypeRef.Int
+        } else {
+          TypeRef.Double
+        }
+
       case ObjectType(List(IndexMember(_, TypeRefTree(CoreType("string"), _), valueType))) =>
         val valueTpe = typeToScala(valueType)
         TypeRef(QualifiedName.Dictionary, List(valueTpe))

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -270,8 +270,8 @@ class Importer(val output: java.io.PrintWriter) {
       case ConstantType(StringLiteral(_)) =>
         TypeRef.String
 
-      case ConstantType(NumberLiteral(d)) =>
-        if (d.isValidInt) {
+      case ConstantType(NumberLiteral(d, hasFloating)) =>
+        if (!hasFloating && d.isValidInt) {
           TypeRef.Int
         } else {
           TypeRef.Double

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -109,7 +109,11 @@ object Trees {
 
   case class BooleanLiteral(value: Boolean) extends Literal
 
-  case class NumberLiteral(value: Double, isValidInt: Boolean) extends Literal
+  sealed trait NumberLiteral extends Literal
+
+  case class IntLiteral(value: Int) extends NumberLiteral
+
+  case class DoubleLiteral(value: Double) extends NumberLiteral
 
   case class StringLiteral(value: String) extends Literal with PropertyName {
     override def name = value

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -109,7 +109,7 @@ object Trees {
 
   case class BooleanLiteral(value: Boolean) extends Literal
 
-  case class NumberLiteral(value: Double) extends Literal
+  case class NumberLiteral(value: Double, hasFloating: Boolean) extends Literal
 
   case class StringLiteral(value: String) extends Literal with PropertyName {
     override def name = value

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -109,7 +109,7 @@ object Trees {
 
   case class BooleanLiteral(value: Boolean) extends Literal
 
-  case class NumberLiteral(value: Double, hasFloating: Boolean) extends Literal
+  case class NumberLiteral(value: Double, isValidInt: Boolean) extends Literal
 
   case class StringLiteral(value: String) extends Literal with PropertyName {
     override def name = value

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefLexical.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefLexical.scala
@@ -41,7 +41,6 @@ class TSDefLexical extends Lexical with StdTokens with ImplicitConversions {
             // not standard, but I guess it could happen nevertheless
             digits => digits.foldLeft(0L)(_ * 8 + _).toString
           }
-        | success("0")
       )
     | stringOf1(digit) ~ opt(stringOf1('.', digit)) ^^ {
         case part1 ~ part2 => part1 + (part2.getOrElse(""))

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -325,7 +325,10 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     stringLit ^^ StringLiteral
 
   lazy val numberLiteral: Parser[NumberLiteral] =
-    numericLit ^^ {s => NumberLiteral(s.toDouble, s.contains("."))}
+    numericLit ^^ {s =>
+      val d = s.toDouble
+      NumberLiteral(d, !s.contains(".") && d.isValidInt)
+    }
 
   private val isCoreTypeName =
     Set("any", "void", "number", "bool", "boolean", "string", "null", "undefined", "never")

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -173,6 +173,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
   lazy val paramType: Parser[TypeTree] = (
       typeDesc
     | stringLiteral ^^ ConstantType
+    | numberLiteral ^^ ConstantType
   )
 
   lazy val optResultType =
@@ -216,6 +217,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     | objectType
     | functionType
     | stringType
+    | numberType
     | typeQuery
     | tupleType
     | thisType
@@ -246,6 +248,9 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
 
   lazy val stringType: Parser[TypeTree] =
     stringLiteral ^^ ConstantType
+
+  lazy val numberType: Parser[TypeTree] =
+    numberLiteral ^^ ConstantType
 
   lazy val thisType: Parser[TypeTree] =
     "this" ^^^ PolymorphicThisType
@@ -318,6 +323,9 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
 
   lazy val stringLiteral: Parser[StringLiteral] =
     stringLit ^^ StringLiteral
+
+  lazy val numberLiteral: Parser[NumberLiteral] =
+    numericLit ^^ {s => NumberLiteral(s.toDouble, s.contains("."))}
 
   private val isCoreTypeName =
     Set("any", "void", "number", "bool", "boolean", "string", "null", "undefined", "never")

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -325,9 +325,13 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     stringLit ^^ StringLiteral
 
   lazy val numberLiteral: Parser[NumberLiteral] =
-    numericLit ^^ {s =>
+    numericLit ^^ { s =>
       val d = s.toDouble
-      NumberLiteral(d, !s.contains(".") && d.isValidInt)
+      if (!s.contains(".") && d.isValidInt) {
+        IntLiteral(d.toInt)
+      } else {
+        DoubleLiteral(d)
+      }
     }
 
   private val isCoreTypeName =

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -296,6 +296,7 @@ object TypeRef {
   val Any = TypeRef(scala_js dot Name("Any"))
   val Dynamic = TypeRef(scala_js dot Name("Dynamic"))
   val Double = TypeRef(scala dot Name("Double"))
+  val Int = TypeRef(scala dot Name("Int"))
   val Boolean = TypeRef(scala dot Name("Boolean"))
   val String = TypeRef(java_lang dot Name("String"))
   val Object = TypeRef(scala_js dot Name("Object"))


### PR DESCRIPTION
Converts the number literal type to `Int` or `Double`.

* `Int` if it is valid-integer and does not have the fraction part, , e.g. `1` or `0x1`
* `Double` if it has the fraction part, e.g. `0.1`, `1.0` or `00000000001001000110100`

Compared to the string literal type, the usage seems very low... but not zero, e.g. [Pixi](https://github.com/pixijs/pixi-typescript/blob/d76f75ccef19d46b5a793d73803661c57480a3a7/pixi.js.d.ts#L1735). 

