### PR TITLE
Parse and ignore private members

### DIFF
--- a/samples/modifiers.ts
+++ b/samples/modifiers.ts
@@ -37,6 +37,9 @@ declare module modifiers {
       readonly scheme: string;
       readonly authority: string;
       readonly path: string;
+      private cache;
+      private updateCache();
+      private static resolve(): String;
   }
 
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -188,6 +188,8 @@ class Importer(val output: java.io.PrintWriter) {
         setterSym.resultType = TypeRef.Unit
         setterSym.isBracketAccess = true
 
+      case PrivateMember => // ignore
+
       case _ =>
         owner.members += new CommentSymbol("??? "+member)
     }

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -174,4 +174,6 @@ object Trees {
 
   case class FunctionMember(name: PropertyName, optional: Boolean,
       signature: FunSignature, modifiers: Modifiers) extends MemberTree
+
+  case object PrivateMember extends MemberTree
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -265,7 +265,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     "{" ~> rep(typeMember <~ opt(";" | ",")) <~ "}"
 
   lazy val typeMember: Parser[MemberTree] =
-    callMember | constructorMember | indexMember | namedMember
+    callMember | constructorMember | indexMember | namedMember | privateMember
 
   lazy val callMember: Parser[MemberTree] =
     functionSignature ^^ CallMember
@@ -283,6 +283,9 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
         | typeAnnotation ^^ (PropertyMember(name, optional, _, mods))
       )
     }
+
+  lazy val privateMember =
+    "private" ~> opt("static") ~> propertyName ~ opt(functionSignature) ^^^ PrivateMember
 
   lazy val modifiers: Parser[Modifiers] =
     rep(modifier).map(_.toSet)


### PR DESCRIPTION
Compiler generated .d.ts files contain private methods/fields in order to avoid name collisions when subclassing in TypeScript https://github.com/Microsoft/TypeScript/issues/1867. The type of private fields is not included.

The approach in this PR is to just ignore them.