### PR TITLE
Add supports for index type query and indexed access type

### DIFF
--- a/samples/keyof.ts
+++ b/samples/keyof.ts
@@ -1,0 +1,28 @@
+// copy example from https://github.com/Microsoft/TypeScript/pull/11929
+interface Thing {
+    name: string;
+    width: number;
+    height: number;
+    inStock: boolean;
+}
+
+type K1 = keyof Thing;  // "name" | "width" | "height" | "inStock"
+type K2 = keyof Thing[];  // "length" | "push" | "pop" | "concat" | ...
+type K3 = keyof { [x: string]: Thing };  // string
+
+type P1 = Thing["name"];  // string
+type P2 = Thing["width" | "height"];  // number
+type P3 = Thing["name" | "inStock"];  // string | boolean
+type P4 = string["charAt"];  // (pos: number) => string
+type P5 = string[]["push"];  // (...items: string[]) => number
+
+// following line will work after merged https://github.com/sjrd/scala-js-ts-importer/pull/47
+// type P6 = string[][0];  // string
+
+// extract example from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/index.d.ts
+interface LoDashStatic {
+    at<T>(
+        object: T | null | undefined,
+        ...props: Array<keyof T>
+    ): Array<T[keyof T]>;
+}

--- a/samples/keyof.ts.scala
+++ b/samples/keyof.ts.scala
@@ -1,0 +1,34 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package keyof {
+
+@js.native
+trait Thing extends js.Object {
+  var name: String = js.native
+  var width: Double = js.native
+  var height: Double = js.native
+  var inStock: Boolean = js.native
+}
+
+@js.native
+trait LoDashStatic extends js.Object {
+  def at[T](`object`: T | Null | Unit, props: String*): js.Array[js.Any] = js.native
+}
+
+@js.native
+@JSGlobalScope
+object Keyof extends js.Object {
+  type K1 = String
+  type K2 = String
+  type K3 = String
+  type P1 = js.Any
+  type P2 = js.Any
+  type P3 = js.Any
+  type P4 = js.Any
+  type P5 = js.Any
+}
+
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -330,6 +330,9 @@ class Importer(val output: java.io.PrintWriter) {
       case RepeatedType(underlying) =>
         TypeRef(Name.REPEATED, List(typeToScala(underlying)))
 
+      case IndexedQueryType(_) =>
+        TypeRef.String
+
       case PolymorphicThisType =>
         TypeRef.This
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -159,6 +159,9 @@ object Trees {
 
   case class RepeatedType(underlying: TypeTree) extends TypeTree
 
+  case class IndexedQueryType(underlying: TypeTree) extends TypeTree
+  case class IndexedAccessType(objectType: TypeTree, name: TypeTree) extends TypeTree
+
   object PolymorphicThisType extends TypeTree
 
   // Type members


### PR DESCRIPTION
TypeScript 2.1 introduced [index type query and indexed access type](https://github.com/Microsoft/TypeScript/pull/11929)(i.e. `keyof` keyword). This pull request adds supports for it.

## :memo: Example
### TypeScript
```typescript
interface Thing {
    name: string;
    width: number;
    height: number;
    inStock: boolean;
}

type K1 = keyof Thing;  // "name" | "width" | "height" | "inStock"
type K2 = keyof Thing[];  // "length" | "push" | "pop" | "concat" | ...
type K3 = keyof { [x: string]: Thing };  // string

type P1 = Thing["name"];  // string
type P2 = Thing["width" | "height"];  // number
type P3 = Thing["name" | "inStock"];  // string | boolean
type P4 = string["charAt"];  // (pos: number) => string
type P5 = string[]["push"];  // (...items: string[]) => number
```

### Scala.js
```scala
object Keyof extends js.Object {
  type K1 = String
  type K2 = String
  type K3 = String
  type P1 = js.Any
  type P2 = js.Any
  type P3 = js.Any
  type P4 = js.Any
  type P5 = js.Any
}
```

## ✨ Convert strategy
### Index Type Query
Index type query`keyof` should be converted string literal type. 
But it's converted to `string` type, because  current Scala type system doesn't support literal type.

### Indexed Access Type
Indexed access type should be converted to its member type.
But it is hard to traverse object member at `Importer#typeToScala` without symbol table.

I believe than inaccurate conversion is better than parse error, so I convert it to `any` type.

## 🎉  Affects of this
`keyof` is widely used at TypeScript definitions. For example, 662 `keyof` exists in [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).

```shell-session
$ git clone git@github.com:DefinitelyTyped/DefinitelyTyped.git
$ cd DefinitelyTyped
$ git grep keyof | wc -l
662
```

It mainly used to express types of object key.

```typescript
at<T extends object>(
  object: T | null | undefined,
  ...props: Array<Many<keyof T>>
): Array<T[keyof T]>;
```