### PR TITLE
Prevent abnormal exit while running test

### DIFF
--- a/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
@@ -31,18 +31,24 @@ object Main {
     val outputFileName = args(1)
     val outputPackage = if (args.length > 2) args(2) else "importedjs"
 
+    if (!importTsFile(inputFileName, outputFileName, outputPackage)) {
+      System.exit(2)
+    }
+}
 
+  def importTsFile(inputFileName: String, outputFileName: String, outputPackage: String): Boolean = {
     parseDefinitions(readerForFile(inputFileName)) match {
       case Some(definitions) =>
         val output = new PrintWriter(new BufferedWriter(
             new FileWriter(outputFileName)))
         try {
           process(definitions, output, outputPackage)
+          true
         } finally {
           output.close()
         }
       case None =>
-        System.exit(2)
+        false
     }
   }
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
@@ -42,7 +42,7 @@ object Main {
           output.close()
         }
       case None =>
-        sys.exit(2)
+        System.exit(2)
     }
   }
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
@@ -31,14 +31,18 @@ object Main {
     val outputFileName = args(1)
     val outputPackage = if (args.length > 2) args(2) else "importedjs"
 
-    val definitions = parseDefinitions(readerForFile(inputFileName))
 
-    val output = new PrintWriter(new BufferedWriter(
-        new FileWriter(outputFileName)))
-    try {
-      process(definitions, output, outputPackage)
-    } finally {
-      output.close()
+    parseDefinitions(readerForFile(inputFileName)) match {
+      case Some(definitions) =>
+        val output = new PrintWriter(new BufferedWriter(
+            new FileWriter(outputFileName)))
+        try {
+          process(definitions, output, outputPackage)
+        } finally {
+          output.close()
+        }
+      case None =>
+        sys.exit(2)
     }
   }
 
@@ -47,18 +51,18 @@ object Main {
     new Importer(output)(definitions, outputPackage)
   }
 
-  private def parseDefinitions(reader: Reader[Char]): List[DeclTree] = {
+  private def parseDefinitions(reader: Reader[Char]): Option[List[DeclTree]] = {
     val parser = new TSDefParser
     parser.parseDefinitions(reader) match {
       case parser.Success(rawCode, _) =>
-        rawCode
+        Some(rawCode)
 
       case parser.NoSuccess(msg, next) =>
         Console.err.println(
             "Parse error at %s\n".format(next.pos.toString) +
             msg + "\n" +
             next.pos.longString)
-        sys.exit(2)
+        None
     }
   }
 

--- a/src/test/scala/org/scalajs/tools/tsimporter/ImporterSpec.scala
+++ b/src/test/scala/org/scalajs/tools/tsimporter/ImporterSpec.scala
@@ -20,7 +20,7 @@ class ImporterSpec extends FunSpec {
         val expected = new File(inputDirectory, input.getName + ".scala")
         val output = new File(outputDir, input.getName + ".scala")
 
-        assert(Main.importTsFile(input.getAbsolutePath, output.getAbsolutePath, input.getName.takeWhile(_ != '.')))
+        assert(Right(()) == Main.importTsFile(input.getAbsolutePath, output.getAbsolutePath, input.getName.takeWhile(_ != '.')))
 
         assert(output.exists())
         assert(contentOf(output) == contentOf(expected))

--- a/src/test/scala/org/scalajs/tools/tsimporter/ImporterSpec.scala
+++ b/src/test/scala/org/scalajs/tools/tsimporter/ImporterSpec.scala
@@ -20,7 +20,7 @@ class ImporterSpec extends FunSpec {
         val expected = new File(inputDirectory, input.getName + ".scala")
         val output = new File(outputDir, input.getName + ".scala")
 
-        Main.main(Array(input.getAbsolutePath, output.getAbsolutePath, input.getName.takeWhile(_ != '.')))
+        assert(Main.importTsFile(input.getAbsolutePath, output.getAbsolutePath, input.getName.takeWhile(_ != '.')))
 
         assert(output.exists())
         assert(contentOf(output) == contentOf(expected))


### PR DESCRIPTION
Parsing error of TypeScript kills sbt interactive session. This is inconvenience while developing.

```shell-session
$ echo 'oops' > samples/oops.ts 
$ sbt
sbt:scala-js-ts-importer> test
Parse error at 1.1
'`import'' expected but identifier oops found
oops
$
```

To improve this, I extract core process from `Main.main`, and use it from `ImportSpec`.
