### PR TITLE
Improve nested object literal

### DIFF
--- a/samples/nestedobjectliteraltypes.ts
+++ b/samples/nestedobjectliteraltypes.ts
@@ -1,0 +1,11 @@
+declare module A {
+  interface Info {
+    settings: {
+      state: {
+        enable: boolean;
+      };
+    };
+  }
+
+  export let objectInfo: Info;
+}

--- a/samples/nestedobjectliteraltypes.ts.scala
+++ b/samples/nestedobjectliteraltypes.ts.scala
@@ -1,0 +1,33 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package nestedobjectliteraltypes {
+
+package A {
+
+@js.native
+trait Info extends js.Object {
+  var settings: `anon$1` = js.native
+}
+
+@js.native
+trait `anon$1` extends js.Object {
+  var state: `anon$2` = js.native
+}
+
+@js.native
+trait `anon$2` extends js.Object {
+  var enable: Boolean = js.native
+}
+
+@js.native
+@JSGlobal("A")
+object A extends js.Object {
+  def objectInfo: Info = js.native
+}
+
+}
+
+}

--- a/samples/nestedobjectliteraltypes.ts.scala
+++ b/samples/nestedobjectliteraltypes.ts.scala
@@ -12,16 +12,14 @@ trait Info extends js.Object {
   var settings: Info.Settings = js.native
 }
 
-@js.native
-object Info extends js.Object {
+object Info {
 
 @js.native
 trait Settings extends js.Object {
   var state: Settings.State = js.native
 }
 
-@js.native
-object Settings extends js.Object {
+object Settings {
 
 @js.native
 trait State extends js.Object {

--- a/samples/nestedobjectliteraltypes.ts.scala
+++ b/samples/nestedobjectliteraltypes.ts.scala
@@ -9,22 +9,22 @@ package A {
 
 @js.native
 trait Info extends js.Object {
-  var settings: Info.settings = js.native
+  var settings: Info.Settings = js.native
 }
 
 @js.native
 object Info extends js.Object {
 
 @js.native
-trait settings extends js.Object {
-  var state: settings.state = js.native
+trait Settings extends js.Object {
+  var state: Settings.State = js.native
 }
 
 @js.native
-object settings extends js.Object {
+object Settings extends js.Object {
 
 @js.native
-trait state extends js.Object {
+trait State extends js.Object {
   var enable: Boolean = js.native
 }
 }

--- a/samples/nestedobjectliteraltypes.ts.scala
+++ b/samples/nestedobjectliteraltypes.ts.scala
@@ -9,17 +9,25 @@ package A {
 
 @js.native
 trait Info extends js.Object {
-  var settings: `anon$1` = js.native
+  var settings: Info.settings = js.native
 }
 
 @js.native
-trait `anon$1` extends js.Object {
-  var state: `anon$2` = js.native
+object Info extends js.Object {
+
+@js.native
+trait settings extends js.Object {
+  var state: settings.state = js.native
 }
 
 @js.native
-trait `anon$2` extends js.Object {
+object settings extends js.Object {
+
+@js.native
+trait state extends js.Object {
   var enable: Boolean = js.native
+}
+}
 }
 
 @js.native

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -206,7 +206,7 @@ class Importer(val output: java.io.PrintWriter) {
         case ObjectType(members) =>
           val module = enclosing.getModuleOrCreate(owner.name)
           module.isGlobal = false
-          val classSym = module.getClassOrCreate(name)
+          val classSym = module.getClassOrCreate(name.capitalize)
           processMembersDecls(module, classSym, members)
           val sym = owner.newField(name, modifiers)
           sym.tpe = TypeRef(QualifiedName(module.name, classSym.name))

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -37,19 +37,19 @@ class Importer(val output: java.io.PrintWriter) {
 
       case VarDecl(IdentName(name), Some(tpe @ ObjectType(members))) =>
         val sym = owner.getModuleOrCreate(name)
-        processMembersDecls(owner, sym, members)
+        processMembersDecls(owner, owner, sym, members)
 
       case ConstDecl(IdentName(name), Some(tpe @ ObjectType(members))) =>
         val sym = owner.getModuleOrCreate(name)
-        processMembersDecls(owner, sym, members)
+        processMembersDecls(owner, owner, sym, members)
 
       case LetDecl(IdentName(name), Some(tpe @ ObjectType(members))) =>
         val sym = owner.getModuleOrCreate(name)
-        processMembersDecls(owner, sym, members)
+        processMembersDecls(owner, owner, sym, members)
 
       case TypeDecl(TypeNameName(name), tpe @ ObjectType(members)) =>
         val sym = owner.getClassOrCreate(name)
-        processMembersDecls(owner, sym, members)
+        processMembersDecls(owner, owner, sym, members)
 
       case EnumDecl(TypeNameName(name), members) =>
         // Type
@@ -79,7 +79,7 @@ class Importer(val output: java.io.PrintWriter) {
           sym.parents += parent
         }
         sym.tparams ++= typeParamsToScala(tparams)
-        processMembersDecls(owner, sym, members)
+        processMembersDecls(owner, owner, sym, members)
         if (!sym.members.exists(_.name == Name.CONSTRUCTOR)) {
           processDefDecl(sym, Name.CONSTRUCTOR,
               FunSignature(Nil, Nil, Some(TypeRefTree(CoreType("void")))))
@@ -94,7 +94,7 @@ class Importer(val output: java.io.PrintWriter) {
           sym.parents += parent
         }
         sym.tparams ++= typeParamsToScala(tparams)
-        processMembersDecls(owner, sym, members)
+        processMembersDecls(owner, owner, sym, members)
 
       case TypeAliasDecl(TypeNameName(name), tparams, alias) =>
         val sym = owner.newTypeAlias(name)
@@ -123,7 +123,8 @@ class Importer(val output: java.io.PrintWriter) {
     }
   }
 
-  private def processMembersDecls(enclosing: ContainerSymbol,
+  private def processMembersDecls(
+      moduleRoot: ContainerSymbol, enclosing: ContainerSymbol,
       owner: ContainerSymbol, members: List[MemberTree]) {
 
     val OwnerName = owner.name
@@ -152,10 +153,10 @@ class Importer(val output: java.io.PrintWriter) {
         assert(owner.isInstanceOf[ClassSymbol],
             s"Cannot process static member $name in module definition")
         val module = enclosing.getModuleOrCreate(owner.name)
-        processPropertyDecl(module, name, tpe, mods)
+        processPropertyDecl(moduleRoot, module, name, tpe, mods)
 
       case PropertyMember(PropertyNameName(name), opt, tpe, mods) =>
-        processPropertyDecl(owner, name, tpe, mods)
+        processPropertyDecl(moduleRoot, owner, name, tpe, mods)
 
       case FunctionMember(PropertyName("constructor"), _, signature, modifiers)
           if owner.isInstanceOf[ClassSymbol] && !modifiers(Modifier.Static) =>
@@ -195,7 +196,7 @@ class Importer(val output: java.io.PrintWriter) {
     }
   }
 
-  private def processPropertyDecl(owner: ContainerSymbol, name: Name,
+  private def processPropertyDecl(moduleRoot: ContainerSymbol, owner: ContainerSymbol, name: Name,
       tpe: TypeTree, modifiers: Modifiers, protectName: Boolean = true) {
     if (name.name != "prototype") {
       tpe match {
@@ -203,6 +204,13 @@ class Importer(val output: java.io.PrintWriter) {
           // alternative notation for overload methods - #3
           for (CallMember(signature) <- members)
             processDefDecl(owner, name, signature, protectName)
+        case ObjectType(members) =>
+          val inner = moduleRoot.newAnonMemberName()
+          val nested = moduleRoot.getClassOrCreate(Name(inner))
+          processMembersDecls(moduleRoot, owner, nested, members)
+
+          val sym = owner.newField(name, modifiers)
+          sym.tpe = typeToScala(TypeRefTree(TypeName(inner)))
         case _ =>
           val sym = owner.newField(name, modifiers)
           if (protectName)

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -14,6 +14,7 @@ import org.scalajs.tools.tsimporter.Trees.{ Modifier, Modifiers }
 
 case class Name(name: String) {
   override def toString() = Utils.scalaEscape(name)
+  def capitalize = Name(name.capitalize)
 }
 
 object Name {

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -186,6 +186,7 @@ class ClassSymbol(nme: Name) extends ContainerSymbol(nme) {
 
 class ModuleSymbol(nme: Name) extends ContainerSymbol(nme) {
   var companionClass: ClassSymbol = _
+  var isGlobal: Boolean = true
 
   override def toString() = s"object $name"
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
@@ -113,10 +113,12 @@ class Printer(private val output: PrintWriter, outputPackage: String) {
       case sym: ModuleSymbol =>
         pln"";
         pln"@js.native"
-        if (currentJSNamespace.isEmpty)
-          pln"@JSGlobal"
-        else
-          pln"""@JSGlobal("$currentJSNamespace${name.name}")"""
+        if (sym.isGlobal) {
+          if (currentJSNamespace.isEmpty)
+            pln"@JSGlobal"
+          else
+            pln"""@JSGlobal("$currentJSNamespace${name.name}")"""
+        }
         pln"object $name extends js.Object {"
         printMemberDecls(sym)
         pln"}"

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Printer.scala
@@ -112,14 +112,16 @@ class Printer(private val output: PrintWriter, outputPackage: String) {
 
       case sym: ModuleSymbol =>
         pln"";
-        pln"@js.native"
         if (sym.isGlobal) {
+          pln"@js.native"
           if (currentJSNamespace.isEmpty)
             pln"@JSGlobal"
           else
             pln"""@JSGlobal("$currentJSNamespace${name.name}")"""
+          pln"object $name extends js.Object {"
+        } else {
+          pln"object $name {"
         }
-        pln"object $name extends js.Object {"
         printMemberDecls(sym)
         pln"}"
 


### PR DESCRIPTION
Nested object literal is converted to `any` type. By converting nested object type to anonymous trait, improve its accuracy.

## :memo: Example
### Source
```typescript
declare interface Info {
  settings: {
    state: {
      enable: boolean;
    };
  };
};
```

### Current

```scala
@js.native
trait Info extends js.Object {
  var settings: js.Any = js.native
}
```

### After merging this pull request
```scala
@js.native
trait Info extends js.Object {
  var settings: Info.settings = js.native
}

@js.native
object Info extends js.Object {

  @js.native
  trait settings extends js.Object {
    var state: settings.state = js.native
  }

  @js.native
  object settings extends js.Object {

    @js.native
    trait state extends js.Object {
      var enable: Boolean = js.native
    }
  }
}
```