### PR TITLE
Add object type support

### DIFF
--- a/samples/extendsobject.ts
+++ b/samples/extendsobject.ts
@@ -1,0 +1,5 @@
+// copy from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/index.d.ts
+declare interface LoDashStatic {
+  at<T extends object>();
+};
+

--- a/samples/extendsobject.ts.scala
+++ b/samples/extendsobject.ts.scala
@@ -1,0 +1,13 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package extendsobject {
+
+@js.native
+trait LoDashStatic extends js.Object {
+  def at[T <: js.Object](): js.Dynamic = js.native
+}
+
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -258,6 +258,7 @@ class Importer(val output: java.io.PrintWriter) {
         val baseTypeRef = base match {
           case TypeName("Array") => QualifiedName.Array
           case TypeName("Function") => QualifiedName.FunctionBase
+          case TypeName("object") => QualifiedName.Object
           case TypeNameName(name) => QualifiedName(name)
           case QualifiedTypeName(qualifier, TypeNameName(name)) =>
             val qual1 = qualifier map (x => Name(x.name))

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -54,6 +54,7 @@ object QualifiedName {
   val Array = scala_js dot Name("Array")
   val Dictionary = scala_js dot Name("Dictionary")
   val FunctionBase = scala_js dot Name("Function")
+  val Object = scala_js dot Name("Object")
   def Function(arity: Int) = scala_js dot Name("Function"+arity)
   def Tuple(arity: Int) = scala_js dot Name("Tuple"+arity)
   val Union = scala_js dot Name("|")


### PR DESCRIPTION
Some type definition of major library(e.g. lodash, jQuery) use `extends object`.

```typescript
at<T extends object>(
            object: T | null | undefined,
            ...props: Array<Many<keyof T>>
        ): Array<T[keyof T]>;
```

Because current scala-js-ts-importer converts `object` to `object`, converted file is not compilable.

## :memo: Example
### Source
```typescript
declare interface LoDashStatic {
  at<T extends object>();
};
```

### Current
```scala
trait LoDashStatic extends js.Object {
  def at[T <: `object`](): js.Dynamic = js.native
}
```
### After merging this pull request
```scala
trait LoDashStatic extends js.Object {
  def at[T <: js.Object](): js.Dynamic = js.native
}
```
