### PR TITLE
Upgrade to sbt 1.1.0 to pull in fix for sbt's stty bug

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.1
+sbt.version=1.1.0


### PR DESCRIPTION
When I run this locally, the terminal gets screwed up because of sbt/sbt#3453. Updating to sbt 1.1 fixes that issue, making this project more convenient to clone and run.