### PR TITLE
Fix #63: don't early-discard specialized signatures

### DIFF
--- a/samples/booleanlit.d.ts.scala
+++ b/samples/booleanlit.d.ts.scala
@@ -9,6 +9,7 @@ package booleanlit {
 
 @js.native
 trait TruthMachine extends js.Object {
+  def update(input: Boolean): Unit = js.native
 }
 
 @js.native

--- a/samples/duplicateliteraltypes.d.ts
+++ b/samples/duplicateliteraltypes.d.ts
@@ -1,0 +1,9 @@
+declare module duplicateliteraltypes {
+    export interface duplicateliteraltypes {
+        duplicate(input: true): void;
+        duplicate(input: false): void;
+
+        duplicate(input: "hello"): void;
+        duplicate(input: string): void;
+    }
+}

--- a/samples/duplicateliteraltypes.d.ts.scala
+++ b/samples/duplicateliteraltypes.d.ts.scala
@@ -1,0 +1,18 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package duplicateliteraltypes {
+
+package duplicateliteraltypes {
+
+@js.native
+trait duplicateliteraltypes extends js.Object {
+  def duplicate(input: Boolean): Unit = js.native
+  def duplicate(input: String): Unit = js.native
+}
+
+}
+
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -225,10 +225,6 @@ class Importer(val output: java.io.PrintWriter) {
 
   private def processDefDecl(owner: ContainerSymbol, name: Name,
       signature: FunSignature, modifiers: Modifiers, protectName: Boolean = true) {
-    // Discard specialized signatures
-    if (signature.params.exists(_.tpe.exists(_.isInstanceOf[ConstantType])))
-      return
-
     val sym = owner.newMethod(name, modifiers)
     if (protectName)
       sym.protectName()


### PR DESCRIPTION
if needed, duplicate method definitions will still be pruned