### PR TITLE
Fix #70: allow leading | in union type definitions

### DIFF
--- a/samples/uniontype.d.ts
+++ b/samples/uniontype.d.ts
@@ -1,0 +1,7 @@
+declare namespace uniontype {
+    export type NumberOrString = number | string;
+    export type LeadingPipe = | number | string;
+    export type MultilineLeadingPipe =
+        | number
+        | string;
+}

--- a/samples/uniontype.d.ts.scala
+++ b/samples/uniontype.d.ts.scala
@@ -1,0 +1,20 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package uniontype {
+
+package uniontype {
+
+@js.native
+@JSGlobal("uniontype")
+object Uniontype extends js.Object {
+  type NumberOrString = Double | String
+  type LeadingPipe = Double | String
+  type MultilineLeadingPipe = Double | String
+}
+
+}
+
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -202,7 +202,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     unionTypeDesc
 
   lazy val unionTypeDesc: Parser[TypeTree] =
-    rep1sep(intersectionTypeDesc, "|") ^^ {
+    opt("|") ~> rep1sep(intersectionTypeDesc, "|") ^^ {
       _.reduceLeft(UnionType)
     }
 


### PR DESCRIPTION
I'm fairly confident that my samples demonstrate the desired syntax and outcome, but I'm less confident that the parser implementation is optimal. (It might be, I'm just inexperienced with the parser-combinator library.)