### PR TITLE
Fix #76: Add string enum support.

### DIFF
--- a/samples/enum.d.ts
+++ b/samples/enum.d.ts
@@ -1,0 +1,16 @@
+declare module enumtype {
+    export enum Color {
+        Red, Green, Blue
+    }
+
+    export enum Button {
+        Submit = "submit",
+        Reset = "reset",
+        Button = "button"
+    }
+
+    export enum Mixed {
+        EMPTY, NUMERIC=2, STRING="string"
+    }
+
+}

--- a/samples/enum.d.ts.scala
+++ b/samples/enum.d.ts.scala
@@ -1,0 +1,54 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package enum {
+
+package enumtype {
+
+@js.native
+sealed trait Color extends js.Object {
+}
+
+@js.native
+@JSGlobal("enumtype.Color")
+object Color extends js.Object {
+  var Red: Color = js.native
+  var Green: Color = js.native
+  var Blue: Color = js.native
+  @JSBracketAccess
+  def apply(value: Color): String = js.native
+}
+
+@js.native
+sealed trait Button extends js.Object {
+}
+
+@js.native
+@JSGlobal("enumtype.Button")
+object Button extends js.Object {
+  var Submit: Button = js.native
+  var Reset: Button = js.native
+  var Button: Button = js.native
+  @JSBracketAccess
+  def apply(value: Button): String = js.native
+}
+
+@js.native
+sealed trait Mixed extends js.Object {
+}
+
+@js.native
+@JSGlobal("enumtype.Mixed")
+object Mixed extends js.Object {
+  var EMPTY: Mixed = js.native
+  var NUMERIC: Mixed = js.native
+  var STRING: Mixed = js.native
+  @JSBracketAccess
+  def apply(value: Mixed): String = js.native
+}
+
+}
+
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -106,7 +106,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     "enum" ~> typeName ~ ("{" ~> ambientEnumBody <~ "}") ^^ EnumDecl
 
   lazy val ambientEnumBody: Parser[List[Ident]] =
-    repsep(identifier <~ opt("=" ~ numericLit), ",") <~ opt(",")
+    repsep(identifier <~ opt("=" ~ (numericLit | stringLit) ), ",") <~ opt(",")
 
   lazy val ambientClassDecl: Parser[DeclTree] =
     (abstractModifier <~ "class") ~ typeName ~ tparams ~ classParent ~ classImplements ~ memberBlock <~ opt(";") ^^ {


### PR DESCRIPTION
This PR fixes https://github.com/sjrd/scala-js-ts-importer/issues/76 by adding [string enum expression](https://www.typescriptlang.org/docs/handbook/enums.html#string-enums) support.  