### PR TITLE
Fix #69: Support readonly indexable types

### DIFF
--- a/samples/indexabletypes.d.ts
+++ b/samples/indexabletypes.d.ts
@@ -3,10 +3,5 @@ interface NumberDictionary {
     [index: string]: number;
 }
 interface ReadonlyStringArray {
-    [index: number]: string;
-}
-
-// extract example from https://github.com/Microsoft/vscode/blob/bc7b804fdec62173b5437d188e6aa64c036d24f0/src/vs/vscode.d.ts#L3601
-export interface WorkspaceConfiguration {
-    readonly [key: string]: any;
+    readonly [index: number]: string;
 }

--- a/samples/indexabletypes.d.ts
+++ b/samples/indexabletypes.d.ts
@@ -1,0 +1,12 @@
+// extract example from https://www.typescriptlang.org/docs/handbook/interfaces.html#indexable-types
+interface NumberDictionary {
+    [index: string]: number;
+}
+interface ReadonlyStringArray {
+    [index: number]: string;
+}
+
+// extract example from https://github.com/Microsoft/vscode/blob/bc7b804fdec62173b5437d188e6aa64c036d24f0/src/vs/vscode.d.ts#L3601
+export interface WorkspaceConfiguration {
+    readonly [key: string]: any;
+}

--- a/samples/indexabletypes.d.ts.scala
+++ b/samples/indexabletypes.d.ts.scala
@@ -17,14 +17,6 @@ trait NumberDictionary extends js.Object {
 trait ReadonlyStringArray extends js.Object {
   @JSBracketAccess
   def apply(index: Double): String = js.native
-  @JSBracketAccess
-  def update(index: Double, v: String): Unit = js.native
-}
-
-@js.native
-trait WorkspaceConfiguration extends js.Object {
-  @JSBracketAccess
-  def apply(key: String): js.Any = js.native
 }
 
 }

--- a/samples/indexabletypes.d.ts.scala
+++ b/samples/indexabletypes.d.ts.scala
@@ -1,0 +1,30 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package indexabletypes {
+
+@js.native
+trait NumberDictionary extends js.Object {
+  @JSBracketAccess
+  def apply(index: String): Double = js.native
+  @JSBracketAccess
+  def update(index: String, v: Double): Unit = js.native
+}
+
+@js.native
+trait ReadonlyStringArray extends js.Object {
+  @JSBracketAccess
+  def apply(index: Double): String = js.native
+  @JSBracketAccess
+  def update(index: Double, v: String): Unit = js.native
+}
+
+@js.native
+trait WorkspaceConfiguration extends js.Object {
+  @JSBracketAccess
+  def apply(key: String): js.Any = js.native
+}
+
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -177,7 +177,7 @@ class Importer(val output: java.io.PrintWriter) {
       case FunctionMember(PropertyNameName(name), opt, signature, modifiers) =>
         processDefDecl(owner, name, signature, modifiers)
 
-      case IndexMember(IdentName(indexName), indexType, valueType) =>
+      case IndexMember(IdentName(indexName), indexType, valueType, readonly) =>
         val indexTpe = typeToScala(indexType)
         val valueTpe = typeToScala(valueType)
 
@@ -186,11 +186,13 @@ class Importer(val output: java.io.PrintWriter) {
         getterSym.resultType = valueTpe
         getterSym.isBracketAccess = true
 
-        val setterSym = owner.newMethod(Name("update"), Set.empty[Modifier])
-        setterSym.params += new ParamSymbol(indexName, indexTpe)
-        setterSym.params += new ParamSymbol(Name("v"), valueTpe)
-        setterSym.resultType = TypeRef.Unit
-        setterSym.isBracketAccess = true
+        if (!readonly){
+          val setterSym = owner.newMethod(Name("update"), Set.empty[Modifier])
+          setterSym.params += new ParamSymbol(indexName, indexTpe)
+          setterSym.params += new ParamSymbol(Name("v"), valueTpe)
+          setterSym.resultType = TypeRef.Unit
+          setterSym.isBracketAccess = true
+        }
 
       case PrivateMember => // ignore
 
@@ -286,7 +288,7 @@ class Importer(val output: java.io.PrintWriter) {
       case ConstantType(BooleanLiteral(_)) =>
         TypeRef.Boolean
 
-      case ObjectType(List(IndexMember(_, TypeRefTree(CoreType("string"), _), valueType))) =>
+      case ObjectType(List(IndexMember(_, TypeRefTree(CoreType("string"), _), valueType, _))) =>
         val valueTpe = typeToScala(valueType)
         TypeRef(QualifiedName.Dictionary, List(valueTpe))
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -177,7 +177,7 @@ class Importer(val output: java.io.PrintWriter) {
       case FunctionMember(PropertyNameName(name), opt, signature, modifiers) =>
         processDefDecl(owner, name, signature, modifiers)
 
-      case IndexMember(IdentName(indexName), indexType, valueType, readonly) =>
+      case IndexMember(IdentName(indexName), indexType, valueType, modifiers) =>
         val indexTpe = typeToScala(indexType)
         val valueTpe = typeToScala(valueType)
 
@@ -186,7 +186,7 @@ class Importer(val output: java.io.PrintWriter) {
         getterSym.resultType = valueTpe
         getterSym.isBracketAccess = true
 
-        if (!readonly){
+        if (!modifiers(Modifier.ReadOnly)){
           val setterSym = owner.newMethod(Name("update"), Set.empty[Modifier])
           setterSym.params += new ParamSymbol(indexName, indexTpe)
           setterSym.params += new ParamSymbol(Name("v"), valueTpe)

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -181,7 +181,7 @@ object Trees {
 
   case class ConstructorMember(signature: FunSignature) extends MemberTree
 
-  case class IndexMember(indexName: Ident, indexType: TypeTree, valueType: TypeTree, readonly: Boolean) extends MemberTree
+  case class IndexMember(indexName: Ident, indexType: TypeTree, valueType: TypeTree, modifiers: Modifiers) extends MemberTree
 
   case class PropertyMember(name: PropertyName, optional: Boolean,
       tpe: TypeTree, modifiers: Modifiers) extends MemberTree

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -181,7 +181,7 @@ object Trees {
 
   case class ConstructorMember(signature: FunSignature) extends MemberTree
 
-  case class IndexMember(indexName: Ident, indexType: TypeTree, valueType: TypeTree) extends MemberTree
+  case class IndexMember(indexName: Ident, indexType: TypeTree, valueType: TypeTree, readonly: Boolean) extends MemberTree
 
   case class PropertyMember(name: PropertyName, optional: Boolean,
       tpe: TypeTree, modifiers: Modifiers) extends MemberTree

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -296,9 +296,9 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     "new" ~> functionSignature ^^ ConstructorMember
 
   lazy val indexMember: Parser[MemberTree] =
-    opt("readonly") ~ ("[" ~> identifier ~ typeAnnotation <~ "]") ~ typeAnnotation ^^ {
-      case readonly ~ (indexName ~ indexType) ~ valueType =>
-        IndexMember(indexName, indexType, valueType, readonly.isDefined)
+    modifiers ~ ("[" ~> identifier ~ typeAnnotation <~ "]") ~ typeAnnotation ^^ {
+      case mods ~ (indexName ~ indexType) ~ valueType =>
+        IndexMember(indexName, indexType, valueType, mods)
     }
 
   lazy val namedMember: Parser[MemberTree] =

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -296,7 +296,10 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     "new" ~> functionSignature ^^ ConstructorMember
 
   lazy val indexMember: Parser[MemberTree] =
-    ("[" ~> identifier ~ typeAnnotation <~ "]") ~ typeAnnotation ^^ IndexMember
+    opt("readonly") ~ ("[" ~> identifier ~ typeAnnotation <~ "]") ~ typeAnnotation ^^ {
+      case readonly ~ (indexName ~ indexType) ~ valueType =>
+        IndexMember(indexName, indexType, valueType, readonly.isDefined)
+    }
 
   lazy val namedMember: Parser[MemberTree] =
     modifiers ~ propertyName ~ optionalMarker >> {


### PR DESCRIPTION
This PR fixes #69.

scala-js-ts-importer can convert indexable types, which has index access a.k.a. bracket access.
TypeScript allows indexable types to have `readonly` modifier, so that the types can prevent assignment to their indices.

This PR adds support of readonly indexable types.

```TypeScript
interface A {
    [key: string]: string;
}
interface B {
    readonly [key: string]: string;
}
```

```Scala
@js.native
trait A extends js.Object {
  @JSBracketAccess
  def apply(index: String): String = js.native
  @JSBracketAccess
  def update(index: String, v: String): Unit = js.native
}

@js.native
trait B extends js.Object {
  @JSBracketAccess
  def apply(index: String): String = js.native
}
```

# Affect of this
5 occurences of readonly indexable types are found in DefinitelyTyped, as of 2018-03-23.

```bash
$ git clone https://github.com/DefinitelyTyped/DefinitelyTyped
$ cd https://github.com/DefinitelyTyped/DefinitelyTyped
$ git grep -E "readonly\s*\[\w+: \w+\]"
types/eslint-visitor-keys/index.d.ts:    readonly [type: string]: ReadonlyArray<string> | undefined;
types/lowdb/index.d.ts:  readonly [n: number]: T;
types/maxmind/index.d.ts:    readonly [index: string]: string;
types/react-tagsinput/index.d.ts:      readonly [prop: string]: any;
types/react-tagsinput/index.d.ts:        readonly [prop: string]: any;
```