### PR TITLE
Fix #68: Support negative value in enums

### DIFF
--- a/samples/enum.d.ts
+++ b/samples/enum.d.ts
@@ -10,7 +10,7 @@ declare module enumtype {
     }
 
     export enum Mixed {
-        EMPTY, NUMERIC=2, STRING="string"
+        EMPTY, NUMERIC = 2, STRING = "string", NEGATIVE = -1
     }
 
 }

--- a/samples/enum.d.ts.scala
+++ b/samples/enum.d.ts.scala
@@ -45,6 +45,7 @@ object Mixed extends js.Object {
   var EMPTY: Mixed = js.native
   var NUMERIC: Mixed = js.native
   var STRING: Mixed = js.native
+  var NEGATIVE: Mixed = js.native
   @JSBracketAccess
   def apply(value: Mixed): String = js.native
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefLexical.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefLexical.scala
@@ -42,8 +42,8 @@ class TSDefLexical extends Lexical with StdTokens with ImplicitConversions {
             digits => digits.foldLeft(0L)(_ * 8 + _).toString
           }
       )
-    | stringOf1(digit) ~ opt(stringOf1('.', digit)) ^^ {
-        case part1 ~ part2 => part1 + (part2.getOrElse(""))
+    | opt('-')  ~ stringOf1(digit) ~ opt(stringOf1('.', digit)) ^^ {
+        case sign ~ part1 ~ part2 => sign.getOrElse("") + part1 + (part2.getOrElse(""))
       }
   ) ^^ NumericLit
 


### PR DESCRIPTION
This PR fixes #68.

I could not find any TypeScript official docs to explain negative value in enums, but obviously it is supported, since there are lots of occurence in the wild.

```bash
$ git clone https://github.com/DefinitelyTyped/DefinitelyTyped
$ cd https://github.com/DefinitelyTyped/DefinitelyTyped
$ git grep -E "\w+ = -[0-9]+" | wc -l
1247
```

The issue https://github.com/Microsoft/TypeScript/issues/150 might explains TypeScript allows negative value in enums.