### PR TITLE
Fix #80: Support private field with type annotation.

### DIFF
--- a/samples/modifiers.d.ts
+++ b/samples/modifiers.d.ts
@@ -38,6 +38,8 @@ declare module modifiers {
       readonly authority: string;
       readonly path: string;
       private cache;
+      private ignoreMe: number;
+      private static ignoreMe2: number;
       private updateCache();
       private static resolve(): String;
   }

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -310,7 +310,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     }
 
   lazy val privateMember =
-    "private" ~> opt("static") ~> propertyName ~ opt(functionSignature) ^^^ PrivateMember
+    "private" ~> opt("static") ~> propertyName ~ opt(functionSignature | typeAnnotation) ^^^ PrivateMember
 
   lazy val modifiers: Parser[Modifiers] =
     rep(modifier).map(_.toSet)


### PR DESCRIPTION
This PR fixes #80 by adding support for private fields with type annotation.

Private methods and private fields without type annotation are already supported.
