### PR TITLE
Introduce CLI options parser so that new options can be added easily

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ val `scala-js-ts-importer` = project.in(file("."))
     mainClass := Some("org.scalajs.tools.tsimporter.Main"),
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6",
+      "com.github.scopt" %% "scopt" % "3.7.0",
       "org.scalatest" %% "scalatest" % "3.0.4" % Test
     )
   )

--- a/src/main/scala/org/scalajs/tools/tsimporter/Config.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Config.scala
@@ -1,10 +1,9 @@
 package org.scalajs.tools.tsimporter
 
-
 case class Config(
-  inputFileName: String = "",
-  outputFileName: String = "",
-  packageName: String = "importedjs"
+    inputFileName: String = "",
+    outputFileName: String = "",
+    packageName: String = "importedjs"
 )
 
 object Config {

--- a/src/main/scala/org/scalajs/tools/tsimporter/Config.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Config.scala
@@ -1,0 +1,27 @@
+package org.scalajs.tools.tsimporter
+
+
+case class Config(
+  inputFileName: String = "",
+  outputFileName: String = "",
+  packageName: String = "importedjs"
+)
+
+object Config {
+  final val parser = new scopt.OptionParser[Config]("scalajs-ts-importer") {
+    arg[String]("<input.d.ts>").required()
+      .text("TypeScript type definition file to be read")
+      .action((i, config) => config.copy(inputFileName = i))
+
+    arg[String]("<output.scala>").required()
+      .text("Output Scala.js file")
+      .action((o, config) => config.copy(outputFileName = o))
+
+    arg[String]("<package>").optional()
+      .text("Package name for the output (defaults to \"importedjs\")")
+      .action((pn, config) => config.copy(packageName = pn))
+
+    help("help").abbr("h")
+      .text("prints help")
+  }
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
@@ -17,26 +17,19 @@ import parser.TSDefParser
 /** Entry point for the TypeScript importer of Scala.js */
 object Main {
   def main(args: Array[String]) {
-    if (args.length < 2) {
-      Console.err.println("""
-        |Usage: scalajs-ts-importer <input.d.ts> <output.scala> [<package>]
-        |  <input.d.ts>     TypeScript type definition file to read
-        |  <output.scala>   Output Scala.js file
-        |  <package>        Package name for the output (defaults to "importedjs")
-      """.stripMargin.trim)
-      System.exit(1)
-    }
+    Config.parser.parse(args, Config()) match {
+      case None => // do nothing. Scopt shows nice error message.
 
-    val inputFileName = args(0)
-    val outputFileName = args(1)
-    val outputPackage = if (args.length > 2) args(2) else "importedjs"
+      case Some(config) =>
+        val outputPackage = config.packageName
 
-    importTsFile(inputFileName, outputFileName, outputPackage) match {
-      case Right(()) =>
-        ()
-      case Left(message) =>
-        Console.err.println(message)
-        System.exit(2)
+        importTsFile(config.inputFileName, config.outputFileName, outputPackage) match {
+          case Right(()) =>
+            ()
+          case Left(message) =>
+            Console.err.println(message)
+            System.exit(2)
+        }
     }
 }
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
@@ -17,21 +17,18 @@ import parser.TSDefParser
 /** Entry point for the TypeScript importer of Scala.js */
 object Main {
   def main(args: Array[String]) {
-    Config.parser.parse(args, Config()) match {
-      case None => // do nothing. Scopt shows nice error message.
+    for (config <- Config.parser.parse(args, Config())) {
+      val outputPackage = config.packageName
 
-      case Some(config) =>
-        val outputPackage = config.packageName
-
-        importTsFile(config.inputFileName, config.outputFileName, outputPackage) match {
-          case Right(()) =>
-            ()
-          case Left(message) =>
-            Console.err.println(message)
-            System.exit(2)
-        }
+      importTsFile(config.inputFileName, config.outputFileName, outputPackage) match {
+        case Right(()) =>
+          ()
+        case Left(message) =>
+          Console.err.println(message)
+          System.exit(2)
+      }
     }
-}
+  }
 
   def importTsFile(inputFileName: String, outputFileName: String, outputPackage: String): Either[String, Unit] = {
     parseDefinitions(readerForFile(inputFileName)).map { definitions =>


### PR DESCRIPTION
Thre are some new feature demands (like #32, #50, #83) that should be user preference.
To add such user preference, new command line options might be required.

This PR adds https://github.com/scopt/scopt as command line parser, so one can add new options easily.

Help message will be 

```bash
sbt:scala-js-ts-importer> run --help
[info] Running org.scalajs.tools.tsimporter.Main --help
Usage: scalajs-ts-importer [options] <input.d.ts> <output.scala> [<package>]

  <input.d.ts>    TypeScript type definition file to be read
  <output.scala>  Output Scala.js file
  <package>       Package name for the output (defaults to "importedjs")
  -h, --help      prints help
```

Error message will be

```bash
sbt:scala-js-ts-importer> run foo.ts
[info] Running org.scalajs.tools.tsimporter.Main foo.ts
Error: Missing argument <output.scala>
Try --help for more information.
```