### PR TITLE
Close the FileReader used to read the input file.

### DIFF
--- a/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
@@ -31,15 +31,20 @@ object Main {
   }
 
   def importTsFile(inputFileName: String, outputFileName: String, outputPackage: String): Either[String, Unit] = {
-    parseDefinitions(readerForFile(inputFileName)).map { definitions =>
-      val output = new PrintWriter(new BufferedWriter(
-          new FileWriter(outputFileName)))
-      try {
-        process(definitions, output, outputPackage)
-        Right(())
-      } finally {
-        output.close()
+    val javaReader = new BufferedReader(new FileReader(inputFileName))
+    try {
+      val reader = new PagedSeqReader(PagedSeq.fromReader(javaReader))
+      parseDefinitions(reader).map { definitions =>
+        val output = new PrintWriter(new BufferedWriter(new FileWriter(outputFileName)))
+        try {
+          process(definitions, output, outputPackage)
+          Right(())
+        } finally {
+          output.close()
+        }
       }
+    } finally {
+      javaReader.close()
     }
   }
 
@@ -60,14 +65,5 @@ object Main {
             msg + "\n" +
             next.pos.longString)
     }
-  }
-
-  /** Builds a [[scala.util.parsing.input.PagedSeqReader]] for a file
-   *
-   *  @param fileName name of the file to be read
-   */
-  private def readerForFile(fileName: String) = {
-    new PagedSeqReader(PagedSeq.fromReader(
-        new BufferedReader(new FileReader(fileName))))
   }
 }


### PR DESCRIPTION
`FileReader` is not closed.
If parsing ~.d.ts failed during running/testing, the opened ~.d.ts can not be modified by other process.

This PR resolves the issue.