### PR TITLE
Update scala-parser-combinators and Scala/sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val `scala-js-ts-importer` = project.in(file("."))
     description := "TypeScript importer for Scala.js",
     mainClass := Some("org.scalajs.tools.tsimporter.Main"),
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6",
+      "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
       "com.github.scopt" %% "scopt" % "3.7.0",
       "org.scalatest" %% "scalatest" % "3.0.4" % Test
     )

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 inThisBuild(Def.settings(
   organization := "org.scalajs.tools",
   version := "0.1-SNAPSHOT",
-  scalaVersion := "2.12.3",
+  scalaVersion := "2.12.8",
   scalacOptions ++= Seq(
     "-deprecation",
     "-unchecked",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.2.7

--- a/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Main.scala
@@ -7,8 +7,6 @@ package org.scalajs.tools.tsimporter
 
 import java.io.{ Console => _, Reader => _, _ }
 
-import scala.collection.immutable.PagedSeq
-
 import Trees._
 
 import scala.util.parsing.input._


### PR DESCRIPTION
Closes #91.
It also addresses [the moved `PagedSeq`](https://github.com/scala/scala-parser-combinators/pull/97)

