### PR TITLE
Ignore "export default IDENTIFIER"

### DIFF
--- a/samples/export.d.ts
+++ b/samples/export.d.ts
@@ -19,3 +19,5 @@ declare module "pixi.js" {
 }
 
 export as namespace asNamespace;
+
+export default Hoge

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -57,6 +57,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     | opt("export") ~> opt("declare") ~> moduleElementDecl1
   ).map(Some(_))
     | "export" ~> lexical.Identifier("as") ~> "namespace" ~> identifier <~ opt(";") ^^^ None
+    | "export" ~> "default" ~> identifier <~ opt(";") ^^^ None
   )
 
   lazy val ambientModuleDecl: Parser[DeclTree] =


### PR DESCRIPTION
Partially adresses #82 regarding [default export](https://www.typescriptlang.org/docs/handbook/modules.html#default-exports)

This PR let parser ignore `export default`.
In future, we may generate some code for default export for utility.
