### PR TITLE
 Address multiple import syntax issues

### DIFF
--- a/samples/assets/module2.d.ts
+++ b/samples/assets/module2.d.ts
@@ -1,0 +1,6 @@
+declare module "module2" {
+    const value: any;
+    export const Foo: any;
+    export const Bar: any;
+    export default value;
+}

--- a/samples/import.d.ts
+++ b/samples/import.d.ts
@@ -8,6 +8,7 @@ import { First, Second } from "module";
 import { Third as T, Fourth } from "module";
 import * as validator from "module";
 import "./assets/module";
+import { First as Alpha, Second as Blavo, } from "module";
 
 declare const hello: String;
 

--- a/samples/import.d.ts
+++ b/samples/import.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="./assets/module" />
+/// <reference path="./assets/module2" />
 // Import variants from https://www.typescriptlang.org/docs/handbook/modules.html#import
 
 import Default from "module";
@@ -10,6 +11,7 @@ import * as validator from "module";
 import "./assets/module";
 import { Third as X } from 'module'
 import { First as Alpha, Second as Blavo, } from "module";
+import Foo, { Bar as Z } from "module2";
 
 declare const hello: String;
 

--- a/samples/import.d.ts
+++ b/samples/import.d.ts
@@ -8,6 +8,7 @@ import { First, Second } from "module";
 import { Third as T, Fourth } from "module";
 import * as validator from "module";
 import "./assets/module";
+import { Third as X } from 'module'
 import { First as Alpha, Second as Blavo, } from "module";
 
 declare const hello: String;

--- a/samples/import.d.ts
+++ b/samples/import.d.ts
@@ -10,7 +10,7 @@ import { Third as T, Fourth } from "module";
 import * as validator from "module";
 import "./assets/module";
 import { Third as X } from 'module'
-import { First as Alpha, Second as Blavo, } from "module";
+import { First as Alpha, Second as Bravo, } from "module";
 import Foo, { Bar as Z } from "module2";
 
 declare const hello: String;

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -127,7 +127,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     ) ~ stringLiteral <~ ";" ^^^ ImportDecl
 
   lazy val importIdentifierSeq =
-    rep1sep(identifier ~ opt(lexical.Identifier("as") ~ identifier), ",")
+    rep1sep(identifier ~ opt(lexical.Identifier("as") ~ identifier), ",") <~ opt(",")
 
   lazy val abstractModifier =
     opt(lexical.Identifier("abstract")) ^^ (_.isDefined)

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -120,10 +120,11 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
 
   lazy val importDecl: Parser[DeclTree] =
     "import" ~> opt(
-      (
+      repsep(
           identifier
-        |  "{" ~ importIdentifierSeq ~ "}"
+        | "{" ~ importIdentifierSeq ~ "}"
         | "*" ~ lexical.Identifier("as") ~ identifier
+        , ","
       ) ~ lexical.Identifier("from")
     ) ~ stringLiteral <~ opt(";") ^^^ ImportDecl
 

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -124,7 +124,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
         |  "{" ~ importIdentifierSeq ~ "}"
         | "*" ~ lexical.Identifier("as") ~ identifier
       ) ~ lexical.Identifier("from")
-    ) ~ stringLiteral <~ ";" ^^^ ImportDecl
+    ) ~ stringLiteral <~ opt(";") ^^^ ImportDecl
 
   lazy val importIdentifierSeq =
     rep1sep(identifier ~ opt(lexical.Identifier("as") ~ identifier), ",") <~ opt(",")


### PR DESCRIPTION
<del>Partially adresses #82</del>
I believe this now closes #82

* Allow missing semicolon at the end of import like `import A from "module"`
* Allow trailing comma in import block like `import { A, B, C, } from "module";`
* Allow comma-separated imports like `import A, { B, C } from "module";`

