### PR TITLE
Allow const enum

### DIFF
--- a/samples/enum.d.ts
+++ b/samples/enum.d.ts
@@ -13,4 +13,8 @@ declare module enumtype {
         EMPTY, NUMERIC = 2, STRING = "string", NEGATIVE = -1
     }
 
+    export const enum RenderLineNumbersType {
+        Off = 0,
+        On = 1,
+    }
 }

--- a/samples/enum.d.ts.scala
+++ b/samples/enum.d.ts.scala
@@ -50,6 +50,19 @@ object Mixed extends js.Object {
   def apply(value: Mixed): String = js.native
 }
 
+@js.native
+sealed trait RenderLineNumbersType extends js.Object {
+}
+
+@js.native
+@JSGlobal("enumtype.RenderLineNumbersType")
+object RenderLineNumbersType extends js.Object {
+  var Off: RenderLineNumbersType = js.native
+  var On: RenderLineNumbersType = js.native
+  @JSBracketAccess
+  def apply(value: RenderLineNumbersType): String = js.native
+}
+
 }
 
 }

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -102,7 +102,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     "function" ~> identifier ~ functionSignature <~ opt(";") ^^ FunctionDecl
 
   lazy val ambientEnumDecl: Parser[DeclTree] =
-    "enum" ~> typeName ~ ("{" ~> ambientEnumBody <~ "}") ^^ EnumDecl
+    opt("const") ~> "enum" ~> typeName ~ ("{" ~> ambientEnumBody <~ "}") ^^ EnumDecl
 
   lazy val ambientEnumBody: Parser[List[Ident]] =
     repsep(identifier <~ opt("=" ~ (numericLit | stringLit) ), ",") <~ opt(",")


### PR DESCRIPTION
Closes #86 

https://www.typescriptlang.org/docs/handbook/enums.html#const-enum
> Const enums can only use constant enum expressions and unlike regular enums they are completely removed during compilation. Const enum members are inlined at use sites. This is possible since const enums cannot have computed members.

Unlike normal enums, `const` enums are inlined at use sites in TypeScript.
That is not related to Scala.js, so this PR treat `const` enum as normal enums.
