### PR TITLE
Add support of type guard

### DIFF
--- a/samples/typeguard.d.ts
+++ b/samples/typeguard.d.ts
@@ -1,0 +1,1 @@
+export function is(value: any): value is Array<any>;

--- a/samples/typeguard.d.ts.scala
+++ b/samples/typeguard.d.ts.scala
@@ -1,0 +1,14 @@
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+
+package typeguard {
+
+@js.native
+@JSGlobalScope
+object Typeguard extends js.Object {
+  def is(value: js.Any): Boolean = js.native
+}
+
+}

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -371,6 +371,9 @@ class Importer(val output: java.io.PrintWriter) {
       case PolymorphicThisType =>
         TypeRef.This
 
+      case TypeGuard =>
+        TypeRef.Boolean
+
       case _ =>
         // ???
         TypeRef.Any

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -175,6 +175,8 @@ object Trees {
 
   object PolymorphicThisType extends TypeTree
 
+  object TypeGuard extends TypeTree
+
   // Type members
 
   case class CallMember(signature: FunSignature) extends MemberTree

--- a/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/parser/TSDefParser.scala
@@ -190,6 +190,7 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
 
   lazy val resultType: Parser[TypeTree] = (
       ("void" ^^^ TypeRef(CoreType("void")))
+    | typeGuard
     | typeDesc
   )
 
@@ -234,6 +235,9 @@ class TSDefParser extends StdTokenParsers with ImplicitConversions {
     | indexTypeQuery
     | "(" ~> typeDesc <~ ")"
   )
+
+  lazy val typeGuard: Parser[TypeTree] =
+    identifier ~ lexical.Identifier("is") ~> singleTypeDesc ^^^ TypeGuard
 
   lazy val typeRef: Parser[TypeRef] =
     baseTypeRef ~ opt(typeArgs) ^^ {


### PR DESCRIPTION
Closes #85

Treat type guard as normal `Boolean`, since Scala does not have a counterpart of [Type Guard in TypeScript](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types)