### PR TITLE
added spec to test all DefinitelyTyped packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 .settings/
 /node_modules
 /package-lock.json
+/DefinitelyTyped

--- a/src/test/scala/org/scalajs/tools/tsimporter/DefinitelyTypedImportSpec.scala
+++ b/src/test/scala/org/scalajs/tools/tsimporter/DefinitelyTypedImportSpec.scala
@@ -1,0 +1,40 @@
+package org.scalajs.tools.tsimporter
+
+import java.io.File
+
+import org.scalatest.FunSpec
+
+class DefinitelyTypedImportSpec extends FunSpec {
+
+  val typesDir = new File("DefinitelyTyped/types")
+
+  describe("DefinitelyTyped") {
+    it("should be present into the root of the directory") {
+      assert(typesDir.exists(), "DefinitelyTyped not present. Please clone https://github.com/DefinitelyTyped/DefinitelyTyped")
+    }
+  }
+
+  describe("scala-js-ts-importer") {
+
+    case class DTProject(name: String, file: File)
+
+    val dtProjects = Option(typesDir.listFiles())
+      .getOrElse(Array.empty)
+      .filter(_.isDirectory)
+      .map(dir => DTProject(dir.getName, dir.toPath.resolve("index.d.ts").toFile))
+      .filter(_.file.isFile)
+
+    val tempOutputFile = File.createTempFile("scala-js-ts-importer-test-", ".scala")
+    tempOutputFile.deleteOnExit()
+    val tempOutputFileName = tempOutputFile.getAbsolutePath
+
+    for (DTProject(name, file) <- dtProjects) it(s"should import '$name'") {
+      val fileName = file.getCanonicalPath
+      Main.importTsFile(fileName, tempOutputFileName, "test") match {
+        case Left(errorMessage) =>
+          fail(s"failed importing $fileName: $errorMessage")
+        case Right(()) =>
+      }
+    }
+  }
+}

--- a/update_definitelyTyped.sh
+++ b/update_definitelyTyped.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/sh
+rm -rf DefinitelyTyped
+git clone --depth=1 https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
I think it's a good idea to test against the DefinitelyTyped code base.
This pr adds a spec that tries to import every project on DefinitelyTyped (output goes into a temporary file).

It yields (at the moment) 5935 test cases.
![image](https://user-images.githubusercontent.com/4148534/59563788-c6d91b80-903e-11e9-9093-e669a182292b.png)
(this incorporates some of the currently open prs)

I'm not really happy with how DefinitelyTyped has to be cloned manually into the root directory at the moment. I tried to do it with sbt, but in the end the manual way was easier and works just as good :smile:. I made a small script that makes it even easier