### PR TITLE
Convert optional parameter to js.UndefOr

### DIFF
--- a/samples/nestedobjectliteraltypes.d.ts
+++ b/samples/nestedobjectliteraltypes.d.ts
@@ -1,7 +1,7 @@
 declare module A {
   interface Info {
     settings: {
-      state: {
+      state?: {
         enable: boolean;
       };
     };

--- a/samples/nestedobjectliteraltypes.d.ts.scala
+++ b/samples/nestedobjectliteraltypes.d.ts.scala
@@ -16,7 +16,7 @@ object Info {
 
 @js.native
 trait Settings extends js.Object {
-  var state: Settings.State = js.native
+  var state: js.UndefOr[Settings.State] = js.native
 }
 
 object Settings {

--- a/samples/numberlit.d.ts.scala
+++ b/samples/numberlit.d.ts.scala
@@ -9,7 +9,7 @@ package numberlit {
 
 @js.native
 trait Machine extends js.Object {
-  var state: Int = js.native
+  var state: js.UndefOr[Int] = js.native
   def setState(flag: Int | Boolean): Int = js.native
 }
 

--- a/samples/stringlit.d.ts.scala
+++ b/samples/stringlit.d.ts.scala
@@ -9,11 +9,11 @@ package stringlit {
 
 @js.native
 trait IEditorOptions extends js.Object {
-  var ariaLabel: String = js.native
-  var rulers: js.Array[Double] = js.native
-  var selectionClipboard: Boolean = js.native
-  var lineNumbers: String | js.Function1[Double, String] = js.native
-  var readable: String | Boolean = js.native
+  var ariaLabel: js.UndefOr[String] = js.native
+  var rulers: js.UndefOr[js.Array[Double]] = js.native
+  var selectionClipboard: js.UndefOr[Boolean] = js.native
+  var lineNumbers: js.UndefOr[String | js.Function1[Double, String]] = js.native
+  var readable: js.UndefOr[String | Boolean] = js.native
 }
 
 @js.native

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -373,8 +373,8 @@ class Importer(val output: java.io.PrintWriter) {
       case PolymorphicThisType =>
         TypeRef.This
 
-      case OptionalType(underlying) =>
-        TypeRef.Optional(typeToScala(underlying))
+      case OptionalType(tpe) =>
+        TypeRef(QualifiedName.UndefOr, List(typeToScala(tpe)))
         
       case _ =>
         // ???

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -215,7 +215,8 @@ class Importer(val output: java.io.PrintWriter) {
           val classSym = module.getClassOrCreate(name.capitalize)
           processMembersDecls(module, classSym, members)
           val sym = owner.newField(name, modifiers)
-          sym.tpe = TypeRef(QualifiedName(module.name, classSym.name))
+          val underlying = TypeRef(QualifiedName(module.name, classSym.name))
+          sym.tpe = if (optional) TypeRef(QualifiedName.UndefOr, List(underlying)) else underlying
         case _ =>
           val sym = owner.newField(name, modifiers)
           if (protectName)

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -160,8 +160,6 @@ object Trees {
 
   case class FunctionType(signature: FunSignature) extends TypeTree
 
-  case class OptionalType(underlying: TypeTree) extends TypeTree
-
   case class UnionType(left: TypeTree, right: TypeTree) extends TypeTree
 
   case class IntersectionType(left: TypeTree, right: TypeTree) extends TypeTree

--- a/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Trees.scala
@@ -160,6 +160,8 @@ object Trees {
 
   case class FunctionType(signature: FunSignature) extends TypeTree
 
+  case class OptionalType(underlying: TypeTree) extends TypeTree
+
   case class UnionType(left: TypeTree, right: TypeTree) extends TypeTree
 
   case class IntersectionType(left: TypeTree, right: TypeTree) extends TypeTree

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -334,18 +334,6 @@ object TypeRef {
   val Null = TypeRef(scala dot Name("Null"))
   val Nothing = TypeRef(scala dot Name("Nothing"))
   val This = Singleton(QualifiedName(Name.THIS))
-
-  object Optional {
-    def apply(types: TypeRef): TypeRef =
-      TypeRef(QualifiedName.UndefOr, List(types))
-
-    def unapply(typeRef: TypeRef): Option[List[TypeRefOrWildcard]] = typeRef match {
-      case TypeRef(QualifiedName.UndefOr, types) =>
-        Some(types)
-
-      case _ => None
-    }
-  }
   
   object Union {
     def apply(types: List[TypeRef]): TypeRef =

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -76,6 +76,7 @@ object QualifiedName {
   def Tuple(arity: Int) = scala_js dot Name("Tuple"+arity)
   val Union = scala_js dot Name("|")
   val Intersection = QualifiedName(Name.INTERSECTION)
+  val Optional = scala_js dot Name("UndefOr")
 }
 
 class Symbol(val name: Name) {
@@ -334,6 +335,18 @@ object TypeRef {
   val Nothing = TypeRef(scala dot Name("Nothing"))
   val This = Singleton(QualifiedName(Name.THIS))
 
+  object Optional {
+    def apply(types: TypeRef): TypeRef =
+      TypeRef(QualifiedName.Optional, List(types))
+
+    def unapply(typeRef: TypeRef): Option[List[TypeRefOrWildcard]] = typeRef match {
+      case TypeRef(QualifiedName.Optional, types) =>
+        Some(types)
+
+      case _ => None
+    }
+  }
+  
   object Union {
     def apply(types: List[TypeRef]): TypeRef =
       TypeRef(QualifiedName.Union, types)

--- a/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/sc/Definitions.scala
@@ -59,6 +59,7 @@ object QualifiedName {
   val FunctionBase = scala_js dot Name("Function")
   val Object = scala_js dot Name("Object")
   val Thenable = scala_js dot Name("Thenable")
+  val UndefOr = scala_js dot Name("UndefOr")
   val JSArray = scala_js dot Name("Array")
   val Float32Array = jstypedarray dot Name("Float32Array")
   val Float64Array = jstypedarray dot Name("Float64Array")
@@ -76,7 +77,6 @@ object QualifiedName {
   def Tuple(arity: Int) = scala_js dot Name("Tuple"+arity)
   val Union = scala_js dot Name("|")
   val Intersection = QualifiedName(Name.INTERSECTION)
-  val Optional = scala_js dot Name("UndefOr")
 }
 
 class Symbol(val name: Name) {
@@ -337,10 +337,10 @@ object TypeRef {
 
   object Optional {
     def apply(types: TypeRef): TypeRef =
-      TypeRef(QualifiedName.Optional, List(types))
+      TypeRef(QualifiedName.UndefOr, List(types))
 
     def unapply(typeRef: TypeRef): Option[List[TypeRefOrWildcard]] = typeRef match {
-      case TypeRef(QualifiedName.Optional, types) =>
+      case TypeRef(QualifiedName.UndefOr, types) =>
         Some(types)
 
       case _ => None


### PR DESCRIPTION
> an optional parameter automatically adds `| undefined`

So let's convert optional parameters and properties to `js.UndefOr[T]`.
https://www.typescriptlang.org/docs/handbook/advanced-types.html#optional-parameters-and-properties