### PR TITLE
Field-only interface can be Scala.js-defined trait

### DIFF
--- a/samples/comma.d.ts.scala
+++ b/samples/comma.d.ts.scala
@@ -11,10 +11,9 @@ class Foo extends js.Object {
   def foo(options: js.Any, key3: String): Unit = js.native
 }
 
-@js.native
 trait Bar extends js.Object {
-  var key1: String = js.native
-  var key2: String = js.native
+  var key1: String
+  var key2: String
 }
 
 }

--- a/samples/enum.d.ts.scala
+++ b/samples/enum.d.ts.scala
@@ -7,7 +7,6 @@ package enum {
 
 package enumtype {
 
-@js.native
 sealed trait Color extends js.Object {
 }
 
@@ -21,7 +20,6 @@ object Color extends js.Object {
   def apply(value: Color): String = js.native
 }
 
-@js.native
 sealed trait Button extends js.Object {
 }
 
@@ -35,7 +33,6 @@ object Button extends js.Object {
   def apply(value: Button): String = js.native
 }
 
-@js.native
 sealed trait Mixed extends js.Object {
 }
 

--- a/samples/extendsintersection.d.ts.scala
+++ b/samples/extendsintersection.d.ts.scala
@@ -7,11 +7,9 @@ package extendsintersection {
 
 package M {
 
-@js.native
 trait A extends js.Object {
 }
 
-@js.native
 trait B extends js.Object {
 }
 

--- a/samples/intersectiontype.d.ts.scala
+++ b/samples/intersectiontype.d.ts.scala
@@ -7,19 +7,16 @@ package intersectiontype {
 
 package intersectiontype {
 
-@js.native
 trait CoreOptions extends js.Object {
-  var statConcurrency: Double = js.native
+  var statConcurrency: Double
 }
 
-@js.native
 trait ExtraOptions extends js.Object {
-  var allowHalfOpen: Boolean = js.native
+  var allowHalfOpen: Boolean
 }
 
-@js.native
 trait MoreExtraOptions extends js.Object {
-  var store: Boolean = js.native
+  var store: Boolean
 }
 
 @js.native

--- a/samples/keyof.d.ts.scala
+++ b/samples/keyof.d.ts.scala
@@ -5,12 +5,11 @@ import js.|
 
 package keyof {
 
-@js.native
 trait Thing extends js.Object {
-  var name: String = js.native
-  var width: Double = js.native
-  var height: Double = js.native
-  var inStock: Boolean = js.native
+  var name: String
+  var width: Double
+  var height: Double
+  var inStock: Boolean
 }
 
 @js.native

--- a/samples/modifiers.d.ts.scala
+++ b/samples/modifiers.d.ts.scala
@@ -7,7 +7,6 @@ package modifiers {
 
 package modifiers {
 
-@js.native
 trait IEvent[T] extends js.Object {
 }
 

--- a/samples/nestedobjectliteraltypes.d.ts.scala
+++ b/samples/nestedobjectliteraltypes.d.ts.scala
@@ -7,23 +7,20 @@ package nestedobjectliteraltypes {
 
 package A {
 
-@js.native
 trait Info extends js.Object {
-  var settings: Info.Settings = js.native
+  var settings: Info.Settings
 }
 
 object Info {
 
-@js.native
 trait Settings extends js.Object {
-  var state: Settings.State = js.native
+  var state: Settings.State
 }
 
 object Settings {
 
-@js.native
 trait State extends js.Object {
-  var enable: Boolean = js.native
+  var enable: Boolean
 }
 }
 }

--- a/samples/stringlit.d.ts.scala
+++ b/samples/stringlit.d.ts.scala
@@ -7,13 +7,12 @@ package stringlit {
 
 package stringlit {
 
-@js.native
 trait IEditorOptions extends js.Object {
-  var ariaLabel: String = js.native
-  var rulers: js.Array[Double] = js.native
-  var selectionClipboard: Boolean = js.native
-  var lineNumbers: String | js.Function1[Double, String] = js.native
-  var readable: String | Boolean = js.native
+  var ariaLabel: String
+  var rulers: js.Array[Double]
+  var selectionClipboard: Boolean
+  var lineNumbers: String | js.Function1[Double, String]
+  var readable: String | Boolean
 }
 
 @js.native

--- a/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
+++ b/src/main/scala/org/scalajs/tools/tsimporter/Importer.scala
@@ -22,7 +22,7 @@ class Importer(val output: java.io.PrintWriter) {
     for (declaration <- declarations)
       processDecl(rootPackage, declaration)
 
-    new Printer(output, outputPackage).printSymbol(rootPackage)
+    new Printer(output, outputPackage).printSymbol(rootPackage, None)
   }
 
   private def processDecl(owner: ContainerSymbol, declaration: DeclTree) {


### PR DESCRIPTION
Closes #50

Fields-only interfaces are commonly used as parameter object in JavaScript/TypeScript.
As an JS/TS library user, I want to instantiate such interface like 
```scala
foo.method(new ParameterObject() {
  var foo = "foo"
  var isBar = false
})
```
But `@js.native` annotation does not allow this.
